### PR TITLE
Add support for `x86` target_arch, update version to `0.1.1`

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   RUSTFLAGS: "-Dwarnings"
 jobs:
-  build-crate:
+  build-x86:
     name: Build and test crate/docs
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -56,6 +56,7 @@ jobs:
   miri:
     name: "Miri"
     runs-on: ubuntu-latest
+    needs: build-x86
     steps:
       - uses: actions/checkout@v4
       - name: Install Miri
@@ -63,7 +64,7 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - name: Test with Miri, Linux target
+      - name: Test with Miri, Linux 64-bit target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test --target x86_64-unknown-linux-gnu
-      - name: Test with Miri, Windows target
-        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test --target x86_64-pc-windows-msvc
+      - name: Test with Miri, Linux 32-bit target
+        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test --target i686-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# `safe_unaligned_simd` changelog
+
+## Version 0.1.1 - 2025-07
+
+[#3][3] - Added `x86` support
+
+## Version 0.1.0 - 2025-06
+Initial release
+
+[3]: https://github.com/okaneco/safe_unaligned_simd/pull/3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_unaligned_simd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Platform-intrinsics that take raw pointers have been wrapped in functions that r
 
 ## Implemented Intrinsics
 
-### `x86_64`
+### `x86`, `x86_64`
 - `sse`, `sse2`, `avx`
 
 Some example function signatures:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Implemented Intrinsics
 //!
-//! ### `x86_64`
+//! ### `x86`, `x86_64`
 //! - `sse`, `sse2`, `avx`
 //!
 //! Currently, there is no plan to implement gather/scatter or masked load/store
@@ -22,5 +22,15 @@
 #![forbid(missing_docs, non_ascii_idents)]
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(target_arch = "x86")]
+pub mod x86;
+
 #[cfg(target_arch = "x86_64")]
-pub mod x86_64;
+mod x86;
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64 {
+    //! Platform-specific intrinsics for `x86_64`.
+
+    #[cfg(target_arch = "x86_64")]
+    pub use crate::x86::*;
+}

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,9 +1,12 @@
-//! Platform-specific intrinsics for `x86_64`.
+//! Platform-specific intrinsics for `x86`.
 #![allow(
     // Boilerplate that would repeat each function description for little benefit
     clippy::missing_safety_doc
 )]
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{__m128i, __m256i};
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{__m128i, __m256i};
 
 mod sse;

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -1,6 +1,12 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m128, __m128d, __m256, __m256d, __m256i};
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{self as arch, __m128, __m128d, __m256, __m256d, __m256i};
 use core::ptr;
 
+#[cfg(target_arch = "x86")]
+use crate::x86::{Is128BitsUnaligned, Is256BitsUnaligned};
+#[cfg(target_arch = "x86_64")]
 use crate::x86_64::{Is128BitsUnaligned, Is256BitsUnaligned};
 
 /// Broadcasts 128 bits from memory (composed of 2 packed double-precision
@@ -10,8 +16,11 @@ use crate::x86_64::{Is128BitsUnaligned, Is256BitsUnaligned};
 #[inline]
 #[target_feature(enable = "avx")]
 pub fn _mm256_broadcast_pd(mem_addr: &__m128d) -> __m256d {
-    // FIXME: Broadcast intrinsics should be marked safe in the near future
-    unsafe { arch::_mm256_broadcast_pd(mem_addr) }
+    // FIXME: Remove unsafe blocks when MSRV includes the safe version
+    #[allow(unused_unsafe)]
+    unsafe {
+        arch::_mm256_broadcast_pd(mem_addr)
+    }
 }
 
 /// Broadcasts 128 bits from memory (composed of 4 packed single-precision
@@ -21,7 +30,11 @@ pub fn _mm256_broadcast_pd(mem_addr: &__m128d) -> __m256d {
 #[inline]
 #[target_feature(enable = "avx")]
 pub fn _mm256_broadcast_ps(mem_addr: &__m128) -> __m256 {
-    unsafe { arch::_mm256_broadcast_ps(mem_addr) }
+    // FIXME: Remove unsafe blocks when MSRV includes the safe version
+    #[allow(unused_unsafe)]
+    unsafe {
+        arch::_mm256_broadcast_ps(mem_addr)
+    }
 }
 
 /// Broadcasts a double-precision (64-bit) floating-point element from memory
@@ -31,7 +44,11 @@ pub fn _mm256_broadcast_ps(mem_addr: &__m128) -> __m256 {
 #[inline]
 #[target_feature(enable = "avx")]
 pub fn _mm256_broadcast_sd(mem_addr: &f64) -> __m256d {
-    unsafe { arch::_mm256_broadcast_sd(mem_addr) }
+    // FIXME: Remove unsafe blocks when MSRV includes the safe version
+    #[allow(unused_unsafe)]
+    unsafe {
+        arch::_mm256_broadcast_sd(mem_addr)
+    }
 }
 
 /// Broadcasts a single-precision (32-bit) floating-point element from memory
@@ -41,7 +58,11 @@ pub fn _mm256_broadcast_sd(mem_addr: &f64) -> __m256d {
 #[inline]
 #[target_feature(enable = "avx")]
 pub fn _mm_broadcast_ss(mem_addr: &f32) -> __m128 {
-    unsafe { arch::_mm_broadcast_ss(mem_addr) }
+    // FIXME: Remove unsafe blocks when MSRV includes the safe version
+    #[allow(unused_unsafe)]
+    unsafe {
+        arch::_mm_broadcast_ss(mem_addr)
+    }
 }
 
 /// Broadcasts a single-precision (32-bit) floating-point element from memory
@@ -51,7 +72,11 @@ pub fn _mm_broadcast_ss(mem_addr: &f32) -> __m128 {
 #[inline]
 #[target_feature(enable = "avx")]
 pub fn _mm256_broadcast_ss(mem_addr: &f32) -> __m256 {
-    unsafe { arch::_mm256_broadcast_ss(mem_addr) }
+    // FIXME: Remove unsafe blocks when MSRV includes the safe version
+    #[allow(unused_unsafe)]
+    unsafe {
+        arch::_mm256_broadcast_ss(mem_addr)
+    }
 }
 
 /// Loads 256-bits (composed of 4 packed double-precision (64-bit)
@@ -186,6 +211,9 @@ pub fn _mm256_storeu2_m128i<T: Is128BitsUnaligned>(hiaddr: &mut T, loaddr: &mut 
 #[cfg(feature = "_avx_test")]
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128, __m256, __m256d, __m256i};
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128, __m256, __m256d, __m256i};
 
     // Fail-safe for tests being run on a CPU that doesn't support `avx`

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m128};
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{self as arch, __m128};
 
 /// Construct a [`__m128`] by duplicating the value read from `mem_addr` into
@@ -71,6 +74,9 @@ pub fn _mm_storeu_ps(mem_addr: &mut [f32; 4], a: __m128) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128};
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128};
 
     fn assert_eq_m128(a: __m128, b: __m128) {

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1,6 +1,12 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m128d, __m128i};
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{self as arch, __m128d, __m128i};
 use core::ptr;
 
+#[cfg(target_arch = "x86")]
+use crate::x86::Is128BitsUnaligned;
+#[cfg(target_arch = "x86_64")]
 use crate::x86_64::Is128BitsUnaligned;
 
 /// Loads a double-precision (64-bit) floating-point element from memory
@@ -197,6 +203,9 @@ pub fn _mm_storeu_si64(mem_addr: &mut [u8; 8], a: __m128i) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128d, __m128i};
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128d, __m128i};
 
     // SAFETY: The `x86_64` target baseline includes `sse` and `sse2`.


### PR DESCRIPTION
Migrate `x86_64` code module to `x86` module
Add change log
Bump version 0.1.1
Update readme
Add `x86` target to Miri test
Add target_arch cfgs for `x86` SIMD types