### PR TITLE
Add `nightly` feature for unstable functions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -26,16 +26,38 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: rust-docs
+
+        # Default build, no features
       - name: Build library
         run: cargo build -v --lib --no-default-features
       - name: Test library
         run: cargo test --no-default-features --lib
-      - name: Test library (avx feature)
-        run: cargo test --no-default-features --lib --features _avx_test
       - name: Doc tests
         run: cargo test --no-default-features --doc
       - name: Build docs
         run: cargo doc --no-deps --no-default-features
+
+        # AVX target_feature enabled doctest and internal feature test
+      - name: Test library (avx feature)
+        run: cargo test --no-default-features --lib --features _avx_test
+      - name: Doc tests (avx target feature)
+        #### Enable +avx for this test
+        env:
+          RUSTFLAGS: "-Dwarnings -Ctarget-feature=+avx"
+        run: cargo test --no-default-features --doc
+
+        # Nightly feature tests
+      - name: Test library (nightly feature)
+        #### Disable +avx
+        env:
+          RUSTFLAGS: "-Dwarnings"
+        run: cargo test --no-default-features --lib --features nightly
+      - name: Doc tests (nightly feature)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: cargo test --no-default-features --doc --features nightly
+      - name: Build docs (nightly)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: cargo doc --no-deps --no-default-features --features nightly
 
   clippy-rustfmt:
     name: Clippy and rustfmt
@@ -57,6 +79,8 @@ jobs:
     name: "Miri"
     runs-on: ubuntu-latest
     needs: build-x86
+    env:
+      RUSTFLAGS: "-Dwarnings -Ctarget-feature=+avx"
     steps:
       - uses: actions/checkout@v4
       - name: Install Miri
@@ -65,6 +89,6 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri, Linux 64-bit target
-        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test --target x86_64-unknown-linux-gnu
+        run: cargo miri test --features _avx_test,nightly --target x86_64-unknown-linux-gnu
       - name: Test with Miri, Linux 32-bit target
-        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test --target i686-unknown-linux-gnu
+        run: cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ categories = ["hardware-support", "api-bindings", "no-std"]
 
 [features]
 default = []
+# Gain access to unstable features which require the nightly compiler
+nightly = []
 
 # Internal feature for target-feature testing
 _avx_test = []

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -291,7 +291,6 @@ mod tests {
         assert_eq!(a, b)
     }
 
-    //
     #[test]
     fn test_mm256_broadcast_pd() {
         assert!(*CPU_HAS_AVX);


### PR DESCRIPTION
Add feature for functions or target features that are not stable
Update CI workflow
 - add `avx` target feature doc tests