### PR TITLE
Abstractions around aarch64 neon loads and stores

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        toolchain: [nightly, beta, stable]
+        toolchain: ["1.88", nightly, beta, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos]
-        toolchain: [nightly, beta, stable]
+        toolchain: ["1.88", nightly, beta, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -91,13 +91,6 @@ jobs:
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --target aarch64-apple-darwin
 
-        # AVX target_feature enabled doctest and internal feature test
-      - name: Enable +avx for RUSTFLAGS
-        env:
-          RUSTFLAGS: "-Dwarnings -Ctarget-feature=+neon"
-        run: echo "Enabling +neon for RUSTFLAGS - ${{ env.RUSTFLAGS }}"
-      - name: Doc tests (neon target feature)
-        run: cargo test --no-default-features --doc
         # Nightly feature tests
       - name: Test library (nightly feature)
         if: ${{ matrix.toolchain == 'nightly' }}
@@ -141,4 +134,4 @@ jobs:
       - name: Test with Miri, Linux 32-bit x86 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu
       - name: Test with Miri, Linux 64-bit aarch64 target
-        run: RUSTFLAGS="-Ctarget-feature=+neon" cargo +nightly miri test --features nightly --all-features --target aarch64-unknown-linux-gnu
+        run: cargo  miri test --features nightly --all-features --target aarch64-unknown-linux-gnu

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -92,7 +92,9 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - name: Test with Miri, Linux 64-bit target
+      - name: Test with Miri, Linux 64-bit x86_64 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target x86_64-unknown-linux-gnu
-      - name: Test with Miri, Linux 32-bit target
+      - name: Test with Miri, Linux 32-bit x86 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu
+      - name: Test with Miri, Linux 64-bit aarch64 target
+        run: RUSTFLAGS="-Ctarget-feature=+neon" cargo +nightly miri test --features nightly --all-features --target aarch64-unknown-linux-gnu

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -65,6 +65,50 @@ jobs:
         if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo doc --no-deps --no-default-features --features nightly
 
+  build-aarch64:
+    name: Build and test crate
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos]
+        toolchain: [nightly, beta, stable]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rust-docs
+          targets: aarch64-apple-darwin
+
+        # Default build, no features
+      - name: Build library
+        run: cargo build -v --lib --no-default-features --target aarch64-apple-darwin
+      - name: Test library
+        run: cargo test --no-default-features --lib --target aarch64-apple-darwin
+      - name: Doc tests
+        run: cargo test --no-default-features --doc --target aarch64-apple-darwin
+      - name: Build docs
+        run: cargo doc --no-deps --no-default-features --target aarch64-apple-darwin
+
+        # AVX target_feature enabled doctest and internal feature test
+      - name: Enable +avx for RUSTFLAGS
+        env:
+          RUSTFLAGS: "-Dwarnings -Ctarget-feature=+neon"
+        run: echo "Enabling +neon for RUSTFLAGS - ${{ env.RUSTFLAGS }}"
+      - name: Doc tests (neon target feature)
+        run: cargo test --no-default-features --doc
+        # Nightly feature tests
+      - name: Test library (nightly feature)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: cargo test --no-default-features --lib --features nightly
+      - name: Doc tests (nightly feature)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: cargo test --no-default-features --doc --features nightly
+      - name: Build docs (nightly)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: cargo doc --no-deps --no-default-features --features nightly
+
   clippy-rustfmt:
     name: Clippy and rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ _avx_test = []
 [package.metadata.docs.rs]
 no-default-features = true
 features = [""]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "safe_unaligned_simd"
 version = "0.1.1"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 exclude = [".github", ""]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Safe wrappers for unaligned SIMD load and store operations.
 
-The goal of this crate is to remove the need for "unnecessary `unsafe`" code when using vector intrinsics with no alignment requirements.
+The goal of this crate is to remove the need for "unnecessary `unsafe`" code when using memory vector intrinsics, with no alignment requirements.
 
 Platform-intrinsics that take raw pointers have been wrapped in functions that receive Rust reference types as arguments.
 
@@ -28,6 +28,17 @@ fn _mm256_loadu2_m128(hiaddr: &[f32; 4], loaddr: &[f32; 4]) -> __m256;
 ```
 
 Currently, there is no plan to implement gather/scatter or masked load/store intrinsics for this platform.
+
+### `aarch64` / `arm64ec`
+- `neon`
+
+Some example function signatures:
+```rust
+#[target_feature(enable = "neon")]
+fn vld2_dup_s8(from: &[i8; 2]) -> int8x8x2_t;
+#[target_feature(enable = "neon")]
+fn vst1q_f64(into: &mut [f64; 2], val: float64x2_t);
+```
 
 ### Other platforms
 

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -93,7 +93,7 @@ macro_rules! vld_n_replicate_k {
 
 macro_rules! assert_size_8bytes {
     ($n:literal registers $ty:ty as $real:ty) => {
-        // Ensure that the type is 128 bits wide.
+        // Ensure that the type has individual vectors 64 bits wide.
         const _: () = ::core::assert!(::core::mem::size_of::<$ty>() == 8 * $n);
         const _: () = ::core::assert!(::core::mem::size_of::<$real>() == 8 * $n);
     };
@@ -101,7 +101,7 @@ macro_rules! assert_size_8bytes {
 
 macro_rules! assert_size_16bytes {
     ($n:literal registers $ty:ty as $real:ty) => {
-        // Ensure that the type is 128 bits wide.
+        // Ensure that the type has individual vectors 128 bits wide.
         const _: () = ::core::assert!(::core::mem::size_of::<$ty>() == 16 * $n);
         const _: () = ::core::assert!(::core::mem::size_of::<$real>() == 16 * $n);
     };
@@ -141,88 +141,88 @@ vld_n_replicate_k! {
     // Loads full registers, so 8 bytes per register
     size: assert_size_8bytes;
 
-    /// load an array of 8 `u8` values to one 8-byte register.
+    /// Load an array of 8 `u8` values to one 8-byte register.
     fn vld1_u8(_: &[u8; 8][..1] as [u8; 8]) -> uint8x8_t;
-    /// load an array of 8 `i8` values to one 8-byte register.
+    /// Load an array of 8 `i8` values to one 8-byte register.
     fn vld1_s8(_: &[i8; 8][..1] as [i8; 8]) -> int8x8_t;
-    /// load an array of 4 `i16` values to one 8-byte register.
+    /// Load an array of 4 `u16` values to one 8-byte register.
     fn vld1_u16(_: &[u16; 4][..1] as [u16; 4]) -> uint16x4_t;
-    /// load an array of 4 `u16` values to one 8-byte register.
+    /// Load an array of 4 `i16` values to one 8-byte register.
     fn vld1_s16(_: &[i16; 4][..1] as [i16; 4]) -> int16x4_t;
-    /// load an array of 2 `u32` values to one 8-byte register.
+    /// Load an array of 2 `u32` values to one 8-byte register.
     fn vld1_u32(_: &[u32; 2][..1] as [u32; 2]) -> uint32x2_t;
-    /// load an array of 2 `i32` values to one 8-byte register.
+    /// Load an array of 2 `i32` values to one 8-byte register.
     fn vld1_s32(_: &[i32; 2][..1] as [i32; 2]) -> int32x2_t;
-    /// load an array of 2 `f32` values to one 8-byte register.
+    /// Load an array of 2 `f32` values to one 8-byte register.
     fn vld1_f32(_: &[f32; 2][..1] as [f32; 2]) -> float32x2_t;
-    /// load one `u64` value to one 8-byte register.
+    /// Load one `u64` value to one 8-byte register.
     fn vld1_u64(_: &[u64; 1][..1] as u64) -> uint64x1_t;
-    /// load one `i64` value to one 8-byte register.
+    /// Load one `i64` value to one 8-byte register.
     fn vld1_s64(_: &[i64; 1][..1] as i64) -> int64x1_t;
-    /// load one `f64` value to one 8-byte register.
+    /// Load one `f64` value to one 8-byte register.
     fn vld1_f64(_: &[f64; 1][..1] as f64) -> float64x1_t;
 
-    /// load arrays of 8 `u8` values to two 8-byte register.
+    /// Load arrays of 8 `u8` values to two 8-byte registers.
     fn vld1_u8_x2(_: &[u8; 8][..2] as [[u8; 8]; 2]) -> uint8x8x2_t;
-    /// load arrays of 8 `i8` values to two 8-byte register.
+    /// Load arrays of 8 `i8` values to two 8-byte registers.
     fn vld1_s8_x2(_: &[i8; 8][..2] as [[i8; 8]; 2]) -> int8x8x2_t;
-    /// load arrays of 4 `i16` values to two 8-byte register.
+    /// Load arrays of 4 `u16` values to two 8-byte registers.
     fn vld1_u16_x2(_: &[u16; 4][..2] as [[u16; 4]; 2]) -> uint16x4x2_t;
-    /// load arrays of 4 `u16` values to two 8-byte register.
+    /// Load arrays of 4 `i16` values to two 8-byte registers.
     fn vld1_s16_x2(_: &[i16; 4][..2] as [[i16; 4]; 2]) -> int16x4x2_t;
-    /// load arrays of 2 `u32` values to two 8-byte register.
+    /// Load arrays of 2 `u32` values to two 8-byte registers.
     fn vld1_u32_x2(_: &[u32; 2][..2] as [[u32; 2]; 2]) -> uint32x2x2_t;
-    /// load arrays of 2 `i32` values to two 8-byte register.
+    /// Load arrays of 2 `i32` values to two 8-byte registers.
     fn vld1_s32_x2(_: &[i32; 2][..2] as [[i32; 2]; 2]) -> int32x2x2_t;
-    /// load arrays of 2 `f32` values to two 8-byte register.
+    /// Load arrays of 2 `f32` values to two 8-byte registers.
     fn vld1_f32_x2(_: &[f32; 2][..2] as [[f32; 2]; 2]) -> float32x2x2_t;
-    /// load two `u64` values to two 8-byte register.
+    /// Load two `u64` values to two 8-byte registers.
     fn vld1_u64_x2(_: &[u64; 1][..2] as [u64; 2]) -> uint64x1x2_t;
-    /// load two `i64` values to two 8-byte register.
+    /// Load two `i64` values to two 8-byte registers.
     fn vld1_s64_x2(_: &[i64; 1][..2] as [i64; 2]) -> int64x1x2_t;
-    /// load two `f64` values to two 8-byte register.
+    /// Load two `f64` values to two 8-byte registers.
     fn vld1_f64_x2(_: &[f64; 1][..2] as [f64; 2]) -> float64x1x2_t;
 
-    /// load arrays of 8 `u8` values to three 8-byte register.
+    /// Load arrays of 8 `u8` values to three 8-byte registers.
     fn vld1_u8_x3(_: &[u8; 8][..3] as [[u8; 8]; 3]) -> uint8x8x3_t;
-    /// load arrays of 8 `i8` values to three 8-byte register.
+    /// Load arrays of 8 `i8` values to three 8-byte registers.
     fn vld1_s8_x3(_: &[i8; 8][..3] as [[i8; 8]; 3]) -> int8x8x3_t;
-    /// load arrays of 4 `i16` values to three 8-byte register.
+    /// Load arrays of 4 `u16` values to three 8-byte registers.
     fn vld1_u16_x3(_: &[u16; 4][..3] as [[u16; 4]; 3]) -> uint16x4x3_t;
-    /// load arrays of 4 `u16` values to three 8-byte register.
+    /// Load arrays of 4 `i16` values to three 8-byte registers.
     fn vld1_s16_x3(_: &[i16; 4][..3] as [[i16; 4]; 3]) -> int16x4x3_t;
-    /// load arrays of 2 `u32` values to three 8-byte register.
+    /// Load arrays of 2 `u32` values to three 8-byte registers.
     fn vld1_u32_x3(_: &[u32; 2][..3] as [[u32; 2]; 3]) -> uint32x2x3_t;
-    /// load arrays of 2 `i32` values to three 8-byte register.
+    /// Load arrays of 2 `i32` values to three 8-byte registers.
     fn vld1_s32_x3(_: &[i32; 2][..3] as [[i32; 2]; 3]) -> int32x2x3_t;
-    /// load arrays of 2 `f32` values to three 8-byte register.
+    /// Load arrays of 2 `f32` values to three 8-byte registers.
     fn vld1_f32_x3(_: &[f32; 2][..3] as [[f32; 2]; 3]) -> float32x2x3_t;
-    /// load two `u64` values to three 8-byte register.
+    /// Load two `u64` values to three 8-byte registers.
     fn vld1_u64_x3(_: &[u64; 1][..3] as [u64; 3]) -> uint64x1x3_t;
-    /// load two `i64` values to three 8-byte register.
+    /// Load two `i64` values to three 8-byte registers.
     fn vld1_s64_x3(_: &[i64; 1][..3] as [i64; 3]) -> int64x1x3_t;
-    /// load two `f64` values to three 8-byte register.
+    /// Load two `f64` values to three 8-byte registers.
     fn vld1_f64_x3(_: &[f64; 1][..3] as [f64; 3]) -> float64x1x3_t;
 
-    /// load arrays of 8 `u8` values to four 8-byte register.
+    /// Load arrays of 8 `u8` values to four 8-byte registers.
     fn vld1_u8_x4(_: &[u8; 8][..4] as [[u8; 8]; 4]) -> uint8x8x4_t;
-    /// load arrays of 8 `i8` values to four 8-byte register.
+    /// Load arrays of 8 `i8` values to four 8-byte registers.
     fn vld1_s8_x4(_: &[i8; 8][..4] as [[i8; 8]; 4]) -> int8x8x4_t;
-    /// load arrays of 4 `i16` values to four 8-byte register.
+    /// Load arrays of 4 `u16` values to four 8-byte registers.
     fn vld1_u16_x4(_: &[u16; 4][..4] as [[u16; 4]; 4]) -> uint16x4x4_t;
-    /// load arrays of 4 `u16` values to four 8-byte register.
+    /// Load arrays of 4 `i16` values to four 8-byte registers.
     fn vld1_s16_x4(_: &[i16; 4][..4] as [[i16; 4]; 4]) -> int16x4x4_t;
-    /// load arrays of 2 `u32` values to four 8-byte register.
+    /// Load arrays of 2 `u32` values to four 8-byte registers.
     fn vld1_u32_x4(_: &[u32; 2][..4] as [[u32; 2]; 4]) -> uint32x2x4_t;
-    /// load arrays of 2 `i32` values to four 8-byte register.
+    /// Load arrays of 2 `i32` values to four 8-byte registers.
     fn vld1_s32_x4(_: &[i32; 2][..4] as [[i32; 2]; 4]) -> int32x2x4_t;
-    /// load arrays of 2 `f32` values to four 8-byte register.
+    /// Load arrays of 2 `f32` values to four 8-byte registers.
     fn vld1_f32_x4(_: &[f32; 2][..4] as [[f32; 2]; 4]) -> float32x2x4_t;
-    /// load two `u64` values to four 8-byte register.
+    /// Load two `u64` values to four 8-byte registers.
     fn vld1_u64_x4(_: &[u64; 1][..4] as [u64; 4]) -> uint64x1x4_t;
-    /// load two `i64` values to four 8-byte register.
+    /// Load two `i64` values to four 8-byte registers.
     fn vld1_s64_x4(_: &[i64; 1][..4] as [i64; 4]) -> int64x1x4_t;
-    /// load two `f64` values to four 8-byte register.
+    /// Load two `f64` values to four 8-byte registers.
     fn vld1_f64_x4(_: &[f64; 1][..4] as [f64; 4]) -> float64x1x4_t;
 }
 
@@ -231,178 +231,178 @@ vld_n_replicate_k! {
     // Loads full registers, so 16 bytes per register
     size: assert_size_16bytes;
 
-    /// load an array of 16 `u8` values to one 16-byte register.
+    /// Load an array of 16 `u8` values to one 16-byte register.
     fn vld1q_u8(_: &[u8; 16][..1] as [u8; 16]) -> uint8x16_t;
-    /// load an array of 16 `i8` values to one 16-byte register.
+    /// Load an array of 16 `i8` values to one 16-byte register.
     fn vld1q_s8(_: &[i8; 16][..1] as [i8; 16]) -> int8x16_t;
-    /// load an array of 8 `i16` values to one 16-byte register.
+    /// Load an array of 8 `u16` values to one 16-byte register.
     fn vld1q_u16(_: &[u16; 8][..1] as [u16; 8]) -> uint16x8_t;
-    /// load an array of 8 `u16` values to one 16-byte register.
+    /// Load an array of 8 `i16` values to one 16-byte register.
     fn vld1q_s16(_: &[i16; 8][..1] as [i16; 8]) -> int16x8_t;
-    /// load an array of 4 `u32` values to one 16-byte register.
+    /// Load an array of 4 `u32` values to one 16-byte register.
     fn vld1q_u32(_: &[u32; 4][..1] as [u32; 4]) -> uint32x4_t;
-    /// load an array of 4 `i32` values to one 16-byte register.
+    /// Load an array of 4 `i32` values to one 16-byte register.
     fn vld1q_s32(_: &[i32; 4][..1] as [i32; 4]) -> int32x4_t;
-    /// load an array of 4 `f32` values to one 16-byte register.
+    /// Load an array of 4 `f32` values to one 16-byte register.
     fn vld1q_f32(_: &[f32; 4][..1] as [f32; 4]) -> float32x4_t;
-    /// load an array of 2 `u64` value to one 16-byte register.
+    /// Load an array of 2 `u64` value to one 16-byte register.
     fn vld1q_u64(_: &[u64; 2][..1] as [u64; 2]) -> uint64x2_t;
-    /// load an array of 2 `i64` value to one 16-byte register.
+    /// Load an array of 2 `i64` value to one 16-byte register.
     fn vld1q_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x2_t;
-    /// load an array of 2 `f64` value to one 16-byte register.
+    /// Load an array of 2 `f64` value to one 16-byte register.
     fn vld1q_f64(_: &[f64; 2][..1] as [f64; 2]) -> float64x2_t;
 
-    /// load two arrays of 16 `u8` values to two 16-byte registers.
+    /// Load two arrays of 16 `u8` values to two 16-byte registers.
     fn vld1q_u8_x2(_: &[u8; 16][..2] as [[u8; 16]; 2]) -> uint8x16x2_t;
-    /// load two arrays of 16 `i8` values to two 16-byte registers.
+    /// Load two arrays of 16 `i8` values to two 16-byte registers.
     fn vld1q_s8_x2(_: &[i8; 16][..2] as [[i8; 16]; 2]) -> int8x16x2_t;
-    /// load two arrays of 8 `i16` values to two 16-byte registers.
+    /// Load two arrays of 8 `u16` values to two 16-byte registers.
     fn vld1q_u16_x2(_: &[u16; 8][..2] as [[u16; 8]; 2]) -> uint16x8x2_t;
-    /// load two arrays of 8 `u16` values to two 16-byte registers.
+    /// Load two arrays of 8 `i16` values to two 16-byte registers.
     fn vld1q_s16_x2(_: &[i16; 8][..2] as [[i16; 8]; 2]) -> int16x8x2_t;
-    /// load two arrays of 4 `u32` values to two 16-byte registers.
+    /// Load two arrays of 4 `u32` values to two 16-byte registers.
     fn vld1q_u32_x2(_: &[u32; 4][..2] as [[u32; 4]; 2]) -> uint32x4x2_t;
-    /// load two arrays of 4 `i32` values to two 16-byte registers.
+    /// Load two arrays of 4 `i32` values to two 16-byte registers.
     fn vld1q_s32_x2(_: &[i32; 4][..2] as [[i32; 4]; 2]) -> int32x4x2_t;
-    /// load two arrays of 4 `f32` values to two 16-byte registers.
+    /// Load two arrays of 4 `f32` values to two 16-byte registers.
     fn vld1q_f32_x2(_: &[f32; 4][..2] as [[f32; 4]; 2]) -> float32x4x2_t;
-    /// load two arrays of 2 `u64` value to two 16-byte registers.
+    /// Load two arrays of 2 `u64` value to two 16-byte registers.
     fn vld1q_u64_x2(_: &[u64; 2][..2] as [[u64; 2]; 2]) -> uint64x2x2_t;
-    /// load two arrays of 2 `i64` value to two 16-byte registers.
+    /// Load two arrays of 2 `i64` value to two 16-byte registers.
     fn vld1q_s64_x2(_: &[i64; 2][..2] as [[i64; 2]; 2]) -> int64x2x2_t;
-    /// load two arrays of 2 `f64` value to two 16-byte registers.
+    /// Load two arrays of 2 `f64` value to two 16-byte registers.
     fn vld1q_f64_x2(_: &[f64; 2][..2] as [[f64; 2]; 2]) -> float64x2x2_t;
 
-    /// load three arrays of 16 `u8` values to three16-byte registers.
+    /// Load three arrays of 16 `u8` values to three16-byte registers.
     fn vld1q_u8_x3(_: &[u8; 16][..3] as [[u8; 16]; 3]) -> uint8x16x3_t;
-    /// load three arrays of 16 `i8` values to three16-byte registers.
+    /// Load three arrays of 16 `i8` values to three16-byte registers.
     fn vld1q_s8_x3(_: &[i8; 16][..3] as [[i8; 16]; 3]) -> int8x16x3_t;
-    /// load three arrays of 8 `i16` values to three16-byte registers.
+    /// Load three arrays of 8 `u16` values to three16-byte registers.
     fn vld1q_u16_x3(_: &[u16; 8][..3] as [[u16; 8]; 3]) -> uint16x8x3_t;
-    /// load three arrays of 8 `u16` values to three16-byte registers.
+    /// Load three arrays of 8 `i16` values to three16-byte registers.
     fn vld1q_s16_x3(_: &[i16; 8][..3] as [[i16; 8]; 3]) -> int16x8x3_t;
-    /// load three arrays of 4 `u32` values to three16-byte registers.
+    /// Load three arrays of 4 `u32` values to three16-byte registers.
     fn vld1q_u32_x3(_: &[u32; 4][..3] as [[u32; 4]; 3]) -> uint32x4x3_t;
-    /// load three arrays of 4 `i32` values to three16-byte registers.
+    /// Load three arrays of 4 `i32` values to three16-byte registers.
     fn vld1q_s32_x3(_: &[i32; 4][..3] as [[i32; 4]; 3]) -> int32x4x3_t;
-    /// load three arrays of 4 `f32` values to three16-byte registers.
+    /// Load three arrays of 4 `f32` values to three16-byte registers.
     fn vld1q_f32_x3(_: &[f32; 4][..3] as [[f32; 4]; 3]) -> float32x4x3_t;
-    /// load three arrays of 2 `u64` value to three16-byte registers.
+    /// Load three arrays of 2 `u64` value to three16-byte registers.
     fn vld1q_u64_x3(_: &[u64; 2][..3] as [[u64; 2]; 3]) -> uint64x2x3_t;
-    /// load three arrays of 2 `i64` value to three16-byte registers.
+    /// Load three arrays of 2 `i64` value to three16-byte registers.
     fn vld1q_s64_x3(_: &[i64; 2][..3] as [[i64; 2]; 3]) -> int64x2x3_t;
-    /// load three arrays of 2 `f64` value to three16-byte registers.
+    /// Load three arrays of 2 `f64` value to three16-byte registers.
     fn vld1q_f64_x3(_: &[f64; 2][..3] as [[f64; 2]; 3]) -> float64x2x3_t;
 
-    /// load four arrays of 16 `u8` values to four 16-byte registers.
+    /// Load four arrays of 16 `u8` values to four 16-byte registers.
     fn vld1q_u8_x4(_: &[u8; 16][..4] as [[u8; 16]; 4]) -> uint8x16x4_t;
-    /// load four arrays of 16 `i8` values to four 16-byte registers.
+    /// Load four arrays of 16 `i8` values to four 16-byte registers.
     fn vld1q_s8_x4(_: &[i8; 16][..4] as [[i8; 16]; 4]) -> int8x16x4_t;
-    /// load four arrays of 8 `i16` values to four 16-byte registers.
+    /// Load four arrays of 8 `u16` values to four 16-byte registers.
     fn vld1q_u16_x4(_: &[u16; 8][..4] as [[u16; 8]; 4]) -> uint16x8x4_t;
-    /// load four arrays of 8 `u16` values to four 16-byte registers.
+    /// Load four arrays of 8 `i16` values to four 16-byte registers.
     fn vld1q_s16_x4(_: &[i16; 8][..4] as [[i16; 8]; 4]) -> int16x8x4_t;
-    /// load four arrays of 4 `u32` values to four 16-byte registers.
+    /// Load four arrays of 4 `u32` values to four 16-byte registers.
     fn vld1q_u32_x4(_: &[u32; 4][..4] as [[u32; 4]; 4]) -> uint32x4x4_t;
-    /// load four arrays of 4 `i32` values to four 16-byte registers.
+    /// Load four arrays of 4 `i32` values to four 16-byte registers.
     fn vld1q_s32_x4(_: &[i32; 4][..4] as [[i32; 4]; 4]) -> int32x4x4_t;
-    /// load four arrays of 4 `f32` values to four 16-byte registers.
+    /// Load four arrays of 4 `f32` values to four 16-byte registers.
     fn vld1q_f32_x4(_: &[f32; 4][..4] as [[f32; 4]; 4]) -> float32x4x4_t;
-    /// load four arrays of 2 `u64` value to four 16-byte registers.
+    /// Load four arrays of 2 `u64` value to four 16-byte registers.
     fn vld1q_u64_x4(_: &[u64; 2][..4] as [[u64; 2]; 4]) -> uint64x2x4_t;
-    /// load four arrays of 2 `i64` value to four 16-byte registers.
+    /// Load four arrays of 2 `i64` value to four 16-byte registers.
     fn vld1q_s64_x4(_: &[i64; 2][..4] as [[i64; 2]; 4]) -> int64x2x4_t;
-    /// load four arrays of 2 `f64` value to four 16-byte registers.
+    /// Load four arrays of 2 `f64` value to four 16-byte registers.
     fn vld1q_f64_x4(_: &[f64; 2][..4] as [[f64; 2]; 4]) -> float64x2x4_t;
 }
 
 vld_n_replicate_k! {
     unsafe: store;
-    // Loads full registers, so 16 bytes per register
+    // Loads full registers, so 8 bytes per register
     size: assert_size_8bytes;
 
-    /// store an array of 8 `u8` values from one 8-byte register.
+    /// Store an array of 8 `u8` values from one 8-byte register.
     fn vst1_u8(_: &[u8; 8][..1] as [u8; 8]) -> uint8x8_t;
-    /// store an array of 8 `i8` values from one 8-byte register.
+    /// Store an array of 8 `i8` values from one 8-byte register.
     fn vst1_s8(_: &[i8; 8][..1] as [i8; 8]) -> int8x8_t;
-    /// store an array of 4 `i16` values from one 8-byte register.
+    /// Store an array of 4 `u16` values from one 8-byte register.
     fn vst1_u16(_: &[u16; 4][..1] as [u16; 4]) -> uint16x4_t;
-    /// store an array of 4 `u16` values from one 8-byte register.
+    /// Store an array of 4 `i16` values from one 8-byte register.
     fn vst1_s16(_: &[i16; 4][..1] as [i16; 4]) -> int16x4_t;
-    /// store an array of 2 `u32` values from one 8-byte register.
+    /// Store an array of 2 `u32` values from one 8-byte register.
     fn vst1_u32(_: &[u32; 2][..1] as [u32; 2]) -> uint32x2_t;
-    /// store an array of 2 `i32` values from one 8-byte register.
+    /// Store an array of 2 `i32` values from one 8-byte register.
     fn vst1_s32(_: &[i32; 2][..1] as [i32; 2]) -> int32x2_t;
-    /// store an array of 2 `f32` values from one 8-byte register.
+    /// Store an array of 2 `f32` values from one 8-byte register.
     fn vst1_f32(_: &[f32; 2][..1] as [f32; 2]) -> float32x2_t;
-    /// store one `u64` value from one 8-byte register.
+    /// Store one `u64` value from one 8-byte register.
     fn vst1_u64(_: &[u64; 1][..1] as u64) -> uint64x1_t;
-    /// store one `i64` value from one 8-byte register.
+    /// Store one `i64` value from one 8-byte register.
     fn vst1_s64(_: &[i64; 1][..1] as i64) -> int64x1_t;
-    /// store one `f64` value from one 8-byte register.
+    /// Store one `f64` value from one 8-byte register.
     fn vst1_f64(_: &[f64; 1][..1] as f64) -> float64x1_t;
 
-    /// store arrays of 8 `u8` values from two 8-byte registers.
+    /// Store arrays of 8 `u8` values from two 8-byte registers.
     fn vst1_u8_x2(_: &[u8; 8][..2] as [[u8; 8]; 2]) -> uint8x8x2_t;
-    /// store arrays of 8 `i8` values from two 8-byte registers.
+    /// Store arrays of 8 `i8` values from two 8-byte registers.
     fn vst1_s8_x2(_: &[i8; 8][..2] as [[i8; 8]; 2]) -> int8x8x2_t;
-    /// store arrays of 4 `i16` values from two 8-byte registers.
+    /// Store arrays of 4 `u16` values from two 8-byte registers.
     fn vst1_u16_x2(_: &[u16; 4][..2] as [[u16; 4]; 2]) -> uint16x4x2_t;
-    /// store arrays of 4 `u16` values from two 8-byte registers.
+    /// Store arrays of 4 `i16` values from two 8-byte registers.
     fn vst1_s16_x2(_: &[i16; 4][..2] as [[i16; 4]; 2]) -> int16x4x2_t;
-    /// store arrays of 2 `u32` values from two 8-byte registers.
+    /// Store arrays of 2 `u32` values from two 8-byte registers.
     fn vst1_u32_x2(_: &[u32; 2][..2] as [[u32; 2]; 2]) -> uint32x2x2_t;
-    /// store arrays of 2 `i32` values from two 8-byte registers.
+    /// Store arrays of 2 `i32` values from two 8-byte registers.
     fn vst1_s32_x2(_: &[i32; 2][..2] as [[i32; 2]; 2]) -> int32x2x2_t;
-    /// store arrays of 2 `f32` values from two 8-byte registers.
+    /// Store arrays of 2 `f32` values from two 8-byte registers.
     fn vst1_f32_x2(_: &[f32; 2][..2] as [[f32; 2]; 2]) -> float32x2x2_t;
-    /// store two `u64` values from two 8-byte registers.
+    /// Store two `u64` values from two 8-byte registers.
     fn vst1_u64_x2(_: &[u64; 1][..2] as [u64; 2]) -> uint64x1x2_t;
-    /// store two `i64` values from two 8-byte registers.
+    /// Store two `i64` values from two 8-byte registers.
     fn vst1_s64_x2(_: &[i64; 1][..2] as [i64; 2]) -> int64x1x2_t;
-    /// store two `f64` values from two 8-byte registers.
+    /// Store two `f64` values from two 8-byte registers.
     fn vst1_f64_x2(_: &[f64; 1][..2] as [f64; 2]) -> float64x1x2_t;
 
-    /// store arrays of 8 `u8` values from three 8-byte registers.
+    /// Store arrays of 8 `u8` values from three 8-byte registers.
     fn vst1_u8_x3(_: &[u8; 8][..3] as [[u8; 8]; 3]) -> uint8x8x3_t;
-    /// store arrays of 8 `i8` values from three 8-byte registers.
+    /// Store arrays of 8 `i8` values from three 8-byte registers.
     fn vst1_s8_x3(_: &[i8; 8][..3] as [[i8; 8]; 3]) -> int8x8x3_t;
-    /// store arrays of 4 `i16` values from three 8-byte registers.
+    /// Store arrays of 4 `u16` values from three 8-byte registers.
     fn vst1_u16_x3(_: &[u16; 4][..3] as [[u16; 4]; 3]) -> uint16x4x3_t;
-    /// store arrays of 4 `u16` values from three 8-byte registers.
+    /// Store arrays of 4 `i16` values from three 8-byte registers.
     fn vst1_s16_x3(_: &[i16; 4][..3] as [[i16; 4]; 3]) -> int16x4x3_t;
-    /// store arrays of 2 `u32` values from three 8-byte registers.
+    /// Store arrays of 2 `u32` values from three 8-byte registers.
     fn vst1_u32_x3(_: &[u32; 2][..3] as [[u32; 2]; 3]) -> uint32x2x3_t;
-    /// store arrays of 2 `i32` values from three 8-byte registers.
+    /// Store arrays of 2 `i32` values from three 8-byte registers.
     fn vst1_s32_x3(_: &[i32; 2][..3] as [[i32; 2]; 3]) -> int32x2x3_t;
-    /// store arrays of 2 `f32` values from three 8-byte registers.
+    /// Store arrays of 2 `f32` values from three 8-byte registers.
     fn vst1_f32_x3(_: &[f32; 2][..3] as [[f32; 2]; 3]) -> float32x2x3_t;
-    /// store two `u64` values from three 8-byte registers.
+    /// Store two `u64` values from three 8-byte registers.
     fn vst1_u64_x3(_: &[u64; 1][..3] as [u64; 3]) -> uint64x1x3_t;
-    /// store two `i64` values from three 8-byte registers.
+    /// Store two `i64` values from three 8-byte registers.
     fn vst1_s64_x3(_: &[i64; 1][..3] as [i64; 3]) -> int64x1x3_t;
-    /// store two `f64` values from three 8-byte registers.
+    /// Store two `f64` values from three 8-byte registers.
     fn vst1_f64_x3(_: &[f64; 1][..3] as [f64; 3]) -> float64x1x3_t;
 
-    /// store arrays of 8 `u8` values from four 8-byte registers.
+    /// Store arrays of 8 `u8` values from four 8-byte registers.
     fn vst1_u8_x4(_: &[u8; 8][..4] as [[u8; 8]; 4]) -> uint8x8x4_t;
-    /// store arrays of 8 `i8` values from four 8-byte registers.
+    /// Store arrays of 8 `i8` values from four 8-byte registers.
     fn vst1_s8_x4(_: &[i8; 8][..4] as [[i8; 8]; 4]) -> int8x8x4_t;
-    /// store arrays of 4 `i16` values from four 8-byte registers.
+    /// Store arrays of 4 `u16` values from four 8-byte registers.
     fn vst1_u16_x4(_: &[u16; 4][..4] as [[u16; 4]; 4]) -> uint16x4x4_t;
-    /// store arrays of 4 `u16` values from four 8-byte registers.
+    /// Store arrays of 4 `i16` values from four 8-byte registers.
     fn vst1_s16_x4(_: &[i16; 4][..4] as [[i16; 4]; 4]) -> int16x4x4_t;
-    /// store arrays of 2 `u32` values from four 8-byte registers.
+    /// Store arrays of 2 `u32` values from four 8-byte registers.
     fn vst1_u32_x4(_: &[u32; 2][..4] as [[u32; 2]; 4]) -> uint32x2x4_t;
-    /// store arrays of 2 `i32` values from four 8-byte registers.
+    /// Store arrays of 2 `i32` values from four 8-byte registers.
     fn vst1_s32_x4(_: &[i32; 2][..4] as [[i32; 2]; 4]) -> int32x2x4_t;
-    /// store arrays of 2 `f32` values from four 8-byte registers.
+    /// Store arrays of 2 `f32` values from four 8-byte registers.
     fn vst1_f32_x4(_: &[f32; 2][..4] as [[f32; 2]; 4]) -> float32x2x4_t;
-    /// store two `u64` values from four 8-byte registers.
+    /// Store two `u64` values from four 8-byte registers.
     fn vst1_u64_x4(_: &[u64; 1][..4] as [u64; 4]) -> uint64x1x4_t;
-    /// store two `i64` values from four 8-byte registers.
+    /// Store two `i64` values from four 8-byte registers.
     fn vst1_s64_x4(_: &[i64; 1][..4] as [i64; 4]) -> int64x1x4_t;
-    /// store two `f64` values from four 8-byte registers.
+    /// Store two `f64` values from four 8-byte registers.
     fn vst1_f64_x4(_: &[f64; 1][..4] as [f64; 4]) -> float64x1x4_t;
 }
 
@@ -411,88 +411,88 @@ vld_n_replicate_k! {
     // Loads full registers, so 16 bytes per register
     size: assert_size_16bytes;
 
-    /// store an array of 16 `u8` values to one 16-byte register.
+    /// Store an array of 16 `u8` values to one 16-byte register.
     fn vst1q_u8(_: &[u8; 16][..1] as [u8; 16]) -> uint8x16_t;
-    /// store an array of 16 `i8` values to one 16-byte register.
+    /// Store an array of 16 `i8` values to one 16-byte register.
     fn vst1q_s8(_: &[i8; 16][..1] as [i8; 16]) -> int8x16_t;
-    /// store an array of 8 `i16` values to one 16-byte register.
+    /// Store an array of 8 `u16` values to one 16-byte register.
     fn vst1q_u16(_: &[u16; 8][..1] as [u16; 8]) -> uint16x8_t;
-    /// store an array of 8 `u16` values to one 16-byte register.
+    /// Store an array of 8 `i16` values to one 16-byte register.
     fn vst1q_s16(_: &[i16; 8][..1] as [i16; 8]) -> int16x8_t;
-    /// store an array of 4 `u32` values to one 16-byte register.
+    /// Store an array of 4 `u32` values to one 16-byte register.
     fn vst1q_u32(_: &[u32; 4][..1] as [u32; 4]) -> uint32x4_t;
-    /// store an array of 4 `i32` values to one 16-byte register.
+    /// Store an array of 4 `i32` values to one 16-byte register.
     fn vst1q_s32(_: &[i32; 4][..1] as [i32; 4]) -> int32x4_t;
-    /// store an array of 4 `f32` values to one 16-byte register.
+    /// Store an array of 4 `f32` values to one 16-byte register.
     fn vst1q_f32(_: &[f32; 4][..1] as [f32; 4]) -> float32x4_t;
-    /// store an array of 2 `u64` value to one 16-byte register.
+    /// Store an array of 2 `u64` value to one 16-byte register.
     fn vst1q_u64(_: &[u64; 2][..1] as [u64; 2]) -> uint64x2_t;
-    /// store an array of 2 `i64` value to one 16-byte register.
+    /// Store an array of 2 `i64` value to one 16-byte register.
     fn vst1q_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x2_t;
-    /// store an array of 2 `f64` value to one 16-byte register.
+    /// Store an array of 2 `f64` value to one 16-byte register.
     fn vst1q_f64(_: &[f64; 2][..1] as [f64; 2]) -> float64x2_t;
 
-    /// store two arrays of 16 `u8` values from two 16-byte registers.
+    /// Store two arrays of 16 `u8` values from two 16-byte registers.
     fn vst1q_u8_x2(_: &[u8; 16][..2] as [[u8; 16]; 2]) -> uint8x16x2_t;
-    /// store two arrays of 16 `i8` values from two 16-byte registers.
+    /// Store two arrays of 16 `i8` values from two 16-byte registers.
     fn vst1q_s8_x2(_: &[i8; 16][..2] as [[i8; 16]; 2]) -> int8x16x2_t;
-    /// store two arrays of 8 `i16` values from two 16-byte registers.
+    /// Store two arrays of 8 `u16` values from two 16-byte registers.
     fn vst1q_u16_x2(_: &[u16; 8][..2] as [[u16; 8]; 2]) -> uint16x8x2_t;
-    /// store two arrays of 8 `u16` values from two 16-byte registers.
+    /// Store two arrays of 8 `i16` values from two 16-byte registers.
     fn vst1q_s16_x2(_: &[i16; 8][..2] as [[i16; 8]; 2]) -> int16x8x2_t;
-    /// store two arrays of 4 `u32` values from two 16-byte registers.
+    /// Store two arrays of 4 `u32` values from two 16-byte registers.
     fn vst1q_u32_x2(_: &[u32; 4][..2] as [[u32; 4]; 2]) -> uint32x4x2_t;
-    /// store two arrays of 4 `i32` values from two 16-byte registers.
+    /// Store two arrays of 4 `i32` values from two 16-byte registers.
     fn vst1q_s32_x2(_: &[i32; 4][..2] as [[i32; 4]; 2]) -> int32x4x2_t;
-    /// store two arrays of 4 `f32` values from two 16-byte registers.
+    /// Store two arrays of 4 `f32` values from two 16-byte registers.
     fn vst1q_f32_x2(_: &[f32; 4][..2] as [[f32; 4]; 2]) -> float32x4x2_t;
-    /// store two arrays of 2 `u64` value from two 16-byte registers.
+    /// Store two arrays of 2 `u64` value from two 16-byte registers.
     fn vst1q_u64_x2(_: &[u64; 2][..2] as [[u64; 2]; 2]) -> uint64x2x2_t;
-    /// store two arrays of 2 `i64` value from two 16-byte registers.
+    /// Store two arrays of 2 `i64` value from two 16-byte registers.
     fn vst1q_s64_x2(_: &[i64; 2][..2] as [[i64; 2]; 2]) -> int64x2x2_t;
-    /// store two arrays of 2 `f64` value from two 16-byte registers.
+    /// Store two arrays of 2 `f64` value from two 16-byte registers.
     fn vst1q_f64_x2(_: &[f64; 2][..2] as [[f64; 2]; 2]) -> float64x2x2_t;
 
-    /// store three arrays of 16 `u8` values from three16-byte registers.
+    /// Store three arrays of 16 `u8` values from three16-byte registers.
     fn vst1q_u8_x3(_: &[u8; 16][..3] as [[u8; 16]; 3]) -> uint8x16x3_t;
-    /// store three arrays of 16 `i8` values from three16-byte registers.
+    /// Store three arrays of 16 `i8` values from three16-byte registers.
     fn vst1q_s8_x3(_: &[i8; 16][..3] as [[i8; 16]; 3]) -> int8x16x3_t;
-    /// store three arrays of 8 `i16` values from three16-byte registers.
+    /// Store three arrays of 8 `u16` values from three16-byte registers.
     fn vst1q_u16_x3(_: &[u16; 8][..3] as [[u16; 8]; 3]) -> uint16x8x3_t;
-    /// store three arrays of 8 `u16` values from three16-byte registers.
+    /// Store three arrays of 8 `i16` values from three16-byte registers.
     fn vst1q_s16_x3(_: &[i16; 8][..3] as [[i16; 8]; 3]) -> int16x8x3_t;
-    /// store three arrays of 4 `u32` values from three16-byte registers.
+    /// Store three arrays of 4 `u32` values from three16-byte registers.
     fn vst1q_u32_x3(_: &[u32; 4][..3] as [[u32; 4]; 3]) -> uint32x4x3_t;
-    /// store three arrays of 4 `i32` values from three16-byte registers.
+    /// Store three arrays of 4 `i32` values from three16-byte registers.
     fn vst1q_s32_x3(_: &[i32; 4][..3] as [[i32; 4]; 3]) -> int32x4x3_t;
-    /// store three arrays of 4 `f32` values from three16-byte registers.
+    /// Store three arrays of 4 `f32` values from three16-byte registers.
     fn vst1q_f32_x3(_: &[f32; 4][..3] as [[f32; 4]; 3]) -> float32x4x3_t;
-    /// store three arrays of 2 `u64` value from three16-byte registers.
+    /// Store three arrays of 2 `u64` value from three16-byte registers.
     fn vst1q_u64_x3(_: &[u64; 2][..3] as [[u64; 2]; 3]) -> uint64x2x3_t;
-    /// store three arrays of 2 `i64` value from three16-byte registers.
+    /// Store three arrays of 2 `i64` value from three16-byte registers.
     fn vst1q_s64_x3(_: &[i64; 2][..3] as [[i64; 2]; 3]) -> int64x2x3_t;
-    /// store three arrays of 2 `f64` value from three16-byte registers.
+    /// Store three arrays of 2 `f64` value from three16-byte registers.
     fn vst1q_f64_x3(_: &[f64; 2][..3] as [[f64; 2]; 3]) -> float64x2x3_t;
 
-    /// store four arrays of 16 `u8` values from four 16-byte registers.
+    /// Store four arrays of 16 `u8` values from four 16-byte registers.
     fn vst1q_u8_x4(_: &[u8; 16][..4] as [[u8; 16]; 4]) -> uint8x16x4_t;
-    /// store four arrays of 16 `i8` values from four 16-byte registers.
+    /// Store four arrays of 16 `i8` values from four 16-byte registers.
     fn vst1q_s8_x4(_: &[i8; 16][..4] as [[i8; 16]; 4]) -> int8x16x4_t;
-    /// store four arrays of 8 `i16` values from four 16-byte registers.
+    /// Store four arrays of 8 `u16` values from four 16-byte registers.
     fn vst1q_u16_x4(_: &[u16; 8][..4] as [[u16; 8]; 4]) -> uint16x8x4_t;
-    /// store four arrays of 8 `u16` values from four 16-byte registers.
+    /// Store four arrays of 8 `i16` values from four 16-byte registers.
     fn vst1q_s16_x4(_: &[i16; 8][..4] as [[i16; 8]; 4]) -> int16x8x4_t;
-    /// store four arrays of 4 `u32` values from four 16-byte registers.
+    /// Store four arrays of 4 `u32` values from four 16-byte registers.
     fn vst1q_u32_x4(_: &[u32; 4][..4] as [[u32; 4]; 4]) -> uint32x4x4_t;
-    /// store four arrays of 4 `i32` values from four 16-byte registers.
+    /// Store four arrays of 4 `i32` values from four 16-byte registers.
     fn vst1q_s32_x4(_: &[i32; 4][..4] as [[i32; 4]; 4]) -> int32x4x4_t;
-    /// store four arrays of 4 `f32` values from four 16-byte registers.
+    /// Store four arrays of 4 `f32` values from four 16-byte registers.
     fn vst1q_f32_x4(_: &[f32; 4][..4] as [[f32; 4]; 4]) -> float32x4x4_t;
-    /// store four arrays of 2 `u64` value from four 16-byte registers.
+    /// Store four arrays of 2 `u64` value from four 16-byte registers.
     fn vst1q_u64_x4(_: &[u64; 2][..4] as [[u64; 2]; 4]) -> uint64x2x4_t;
-    /// store four arrays of 2 `i64` value from four 16-byte registers.
+    /// Store four arrays of 2 `i64` value from four 16-byte registers.
     fn vst1q_s64_x4(_: &[i64; 2][..4] as [[i64; 2]; 4]) -> int64x2x4_t;
-    /// store four arrays of 2 `f64` value from four 16-byte registers.
+    /// Store four arrays of 2 `f64` value from four 16-byte registers.
     fn vst1q_f64_x4(_: &[f64; 2][..4] as [[f64; 2]; 4]) -> float64x2x4_t;
 }
 

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -536,6 +536,8 @@ mod tests {
     // which eliminates most forms of type confusion we could have inadvertently introduced by
     // mismatching intrinsic types and exposed memory types. The syntax for this macro also formats
     // more consistently under rustfmt (one line each).
+    //
+    // Safety: `base` must be a Pod (integer) type and `ty` must be a SIMD vector type
     macro_rules! test_vld1_from_slice {
         ($(#[$attr:meta])* fn $testname:ident, $intrinsic:ident, $base:ty, $ty:ty $(, $with:expr)?) => {
             #[test]
@@ -543,6 +545,11 @@ mod tests {
             $(#[$attr])*
             fn $testname() {
                 fn assert_eq<const N: usize>(v: $ty, val: [$base; N]) {
+                    assert!(core::mem::size_of::<$ty>() == core::mem::size_of::<[$base; N]>());
+                    // Safety: transmuting a SIMD vector to its array representation which are Pod.
+                    // This can not utilized `transmute` since the size of `val` is polymorphic,
+                    // and the compiler rejects a transmute it can not statically prove to be
+                    // between equivalently sized types, e.g. dependently sized type on `N`.
                     let v = unsafe { core::mem::transmute_copy::<$ty, [$base; N]>(&v) };
                     assert_eq!(v, val);
                 }
@@ -574,47 +581,39 @@ mod tests {
     test_vld1_from_slice!(fn test_vld1_i64, vld1_s64, i64, arch::int64x1_t, |[val]: [_; 1]| val);
     test_vld1_from_slice!(fn test_vld1_f64, vld1_f64, f64, arch::float64x1_t, |[val]: [_; 1]| val);
 
-    fn distribute2<T: Copy, const N: usize, const M: usize>(v: [T; N]) -> [[T; M]; 2] {
-        <[[T; M]; 2]>::try_from(v.as_chunks::<M>().0).unwrap()
+    fn as_chunks<T: Copy, const L: usize, const N: usize, const M: usize>(v: [T; N]) -> [[T; M]; L] {
+        <[[T; M]; L]>::try_from(v.as_chunks::<M>().0).unwrap()
     }
 
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x2, vld1_u8_x2, u8, arch::uint8x8x2_t, distribute2::<_, 16, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x2, vld1_s8_x2, i8, arch::int8x8x2_t, distribute2::<_, 16, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x2, vld1_u16_x2, u16, arch::uint16x4x2_t, distribute2::<_, 8, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x2, vld1_s16_x2, i16, arch::int16x4x2_t, distribute2::<_, 8, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x2, vld1_u32_x2, u32, arch::uint32x2x2_t, distribute2::<_, 4, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x2, vld1_s32_x2, i32, arch::int32x2x2_t, distribute2::<_, 4, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x2, vld1_f32_x2, f32, arch::float32x2x2_t, distribute2::<_, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x2, vld1_u8_x2, u8, arch::uint8x8x2_t, as_chunks::<_, 2, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x2, vld1_s8_x2, i8, arch::int8x8x2_t, as_chunks::<_, 2, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x2, vld1_u16_x2, u16, arch::uint16x4x2_t, as_chunks::<_, 2, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x2, vld1_s16_x2, i16, arch::int16x4x2_t, as_chunks::<_, 2, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x2, vld1_u32_x2, u32, arch::uint32x2x2_t, as_chunks::<_, 2, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x2, vld1_s32_x2, i32, arch::int32x2x2_t, as_chunks::<_, 2, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x2, vld1_f32_x2, f32, arch::float32x2x2_t, as_chunks::<_, 2, 4, 2>);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u64_x2, vld1_u64_x2, u64, arch::uint64x1x2_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i64_x2, vld1_s64_x2, i64, arch::int64x1x2_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f64_x2, vld1_f64_x2, f64, arch::float64x1x2_t);
 
-    fn distribute3<T: Copy, const N: usize, const M: usize>(v: [T; N]) -> [[T; M]; 3] {
-        <[[T; M]; 3]>::try_from(v.as_chunks::<M>().0).unwrap()
-    }
-
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x3, vld1_u8_x3, u8, arch::uint8x8x3_t, distribute3::<_, 24, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x3, vld1_s8_x3, i8, arch::int8x8x3_t, distribute3::<_, 24, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x3, vld1_u16_x3, u16, arch::uint16x4x3_t, distribute3::<_, 12, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x3, vld1_s16_x3, i16, arch::int16x4x3_t, distribute3::<_, 12, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x3, vld1_u32_x3, u32, arch::uint32x2x3_t, distribute3::<_, 6, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x3, vld1_s32_x3, i32, arch::int32x2x3_t, distribute3::<_, 6, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x3, vld1_f32_x3, f32, arch::float32x2x3_t, distribute3::<_, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x3, vld1_u8_x3, u8, arch::uint8x8x3_t, as_chunks::<_, 3, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x3, vld1_s8_x3, i8, arch::int8x8x3_t, as_chunks::<_, 3, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x3, vld1_u16_x3, u16, arch::uint16x4x3_t, as_chunks::<_, 3, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x3, vld1_s16_x3, i16, arch::int16x4x3_t, as_chunks::<_, 3, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x3, vld1_u32_x3, u32, arch::uint32x2x3_t, as_chunks::<_, 3, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x3, vld1_s32_x3, i32, arch::int32x2x3_t, as_chunks::<_, 3, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x3, vld1_f32_x3, f32, arch::float32x2x3_t, as_chunks::<_, 3, 6, 2>);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u64_x3, vld1_u64_x3, u64, arch::uint64x1x3_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i64_x3, vld1_s64_x3, i64, arch::int64x1x3_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f64_x3, vld1_f64_x3, f64, arch::float64x1x3_t);
 
-    fn distribute4<T: Copy, const N: usize, const M: usize>(v: [T; N]) -> [[T; M]; 4] {
-        <[[T; M]; 4]>::try_from(v.as_chunks::<M>().0).unwrap()
-    }
-
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x4, vld1_u8_x4, u8, arch::uint8x8x4_t, distribute4::<_, 32, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x4, vld1_s8_x4, i8, arch::int8x8x4_t, distribute4::<_, 32, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x4, vld1_u16_x4, u16, arch::uint16x4x4_t, distribute4::<_, 16, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x4, vld1_s16_x4, i16, arch::int16x4x4_t, distribute4::<_, 16, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x4, vld1_u32_x4, u32, arch::uint32x2x4_t, distribute4::<_, 8, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x4, vld1_s32_x4, i32, arch::int32x2x4_t, distribute4::<_, 8, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x4, vld1_f32_x4, f32, arch::float32x2x4_t, distribute4::<_, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u8_x4, vld1_u8_x4, u8, arch::uint8x8x4_t, as_chunks::<_, 4, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i8_x4, vld1_s8_x4, i8, arch::int8x8x4_t, as_chunks::<_, 4, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u16_x4, vld1_u16_x4, u16, arch::uint16x4x4_t, as_chunks::<_, 4, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i16_x4, vld1_s16_x4, i16, arch::int16x4x4_t, as_chunks::<_, 4, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u32_x4, vld1_u32_x4, u32, arch::uint32x2x4_t, as_chunks::<_, 4, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i32_x4, vld1_s32_x4, i32, arch::int32x2x4_t, as_chunks::<_, 4, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f32_x4, vld1_f32_x4, f32, arch::float32x2x4_t, as_chunks::<_, 4, 8, 2>);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_u64_x4, vld1_u64_x4, u64, arch::uint64x1x4_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_i64_x4, vld1_s64_x4, i64, arch::int64x1x4_t);
     test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1_f64_x4, vld1_f64_x4, f64, arch::float64x1x4_t);
@@ -630,43 +629,45 @@ mod tests {
     test_vld1_from_slice!(fn test_vld1q_i64, vld1q_s64, i64, arch::int64x2_t);
     test_vld1_from_slice!(fn test_vld1q_f64, vld1q_f64, f64, arch::float64x2_t);
 
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x2, vld1q_u8_x2, u8, arch::uint8x16x2_t, distribute2::<_, 32, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x2, vld1q_s8_x2, i8, arch::int8x16x2_t, distribute2::<_, 32, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x2, vld1q_u16_x2, u16, arch::uint16x8x2_t, distribute2::<_, 16, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x2, vld1q_s16_x2, i16, arch::int16x8x2_t, distribute2::<_, 16, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x2, vld1q_u32_x2, u32, arch::uint32x4x2_t, distribute2::<_, 8, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x2, vld1q_s32_x2, i32, arch::int32x4x2_t, distribute2::<_, 8, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x2, vld1q_f32_x2, f32, arch::float32x4x2_t, distribute2::<_, 8, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x2, vld1q_u64_x2, u64, arch::uint64x2x2_t, distribute2::<_, 4, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x2, vld1q_s64_x2, i64, arch::int64x2x2_t, distribute2::<_, 4, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x2, vld1q_f64_x2, f64, arch::float64x2x2_t, distribute2::<_, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x2, vld1q_u8_x2, u8, arch::uint8x16x2_t, as_chunks::<_, 2, 32, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x2, vld1q_s8_x2, i8, arch::int8x16x2_t, as_chunks::<_, 2, 32, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x2, vld1q_u16_x2, u16, arch::uint16x8x2_t, as_chunks::<_, 2, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x2, vld1q_s16_x2, i16, arch::int16x8x2_t, as_chunks::<_, 2, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x2, vld1q_u32_x2, u32, arch::uint32x4x2_t, as_chunks::<_, 2, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x2, vld1q_s32_x2, i32, arch::int32x4x2_t, as_chunks::<_, 2, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x2, vld1q_f32_x2, f32, arch::float32x4x2_t, as_chunks::<_, 2, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x2, vld1q_u64_x2, u64, arch::uint64x2x2_t, as_chunks::<_, 2, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x2, vld1q_s64_x2, i64, arch::int64x2x2_t, as_chunks::<_, 2, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x2, vld1q_f64_x2, f64, arch::float64x2x2_t, as_chunks::<_, 2, 4, 2>);
 
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x3, vld1q_u8_x3, u8, arch::uint8x16x3_t, distribute3::<_, 48, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x3, vld1q_s8_x3, i8, arch::int8x16x3_t, distribute3::<_, 48, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x3, vld1q_u16_x3, u16, arch::uint16x8x3_t, distribute3::<_, 24, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x3, vld1q_s16_x3, i16, arch::int16x8x3_t, distribute3::<_, 24, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x3, vld1q_u32_x3, u32, arch::uint32x4x3_t, distribute3::<_, 12, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x3, vld1q_s32_x3, i32, arch::int32x4x3_t, distribute3::<_, 12, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x3, vld1q_f32_x3, f32, arch::float32x4x3_t, distribute3::<_, 12, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x3, vld1q_u64_x3, u64, arch::uint64x2x3_t, distribute3::<_, 6, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x3, vld1q_s64_x3, i64, arch::int64x2x3_t, distribute3::<_, 6, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x3, vld1q_f64_x3, f64, arch::float64x2x3_t, distribute3::<_, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x3, vld1q_u8_x3, u8, arch::uint8x16x3_t,as_chunks::<_, 3, 48, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x3, vld1q_s8_x3, i8, arch::int8x16x3_t, as_chunks::<_, 3, 48, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x3, vld1q_u16_x3, u16, arch::uint16x8x3_t, as_chunks::<_, 3, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x3, vld1q_s16_x3, i16, arch::int16x8x3_t, as_chunks::<_, 3, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x3, vld1q_u32_x3, u32, arch::uint32x4x3_t, as_chunks::<_, 3, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x3, vld1q_s32_x3, i32, arch::int32x4x3_t, as_chunks::<_, 3, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x3, vld1q_f32_x3, f32, arch::float32x4x3_t, as_chunks::<_, 3, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x3, vld1q_u64_x3, u64, arch::uint64x2x3_t, as_chunks::<_, 3, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x3, vld1q_s64_x3, i64, arch::int64x2x3_t, as_chunks::<_, 3, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x3, vld1q_f64_x3, f64, arch::float64x2x3_t, as_chunks::<_, 3, 6, 2>);
 
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x4, vld1q_u8_x4, u8, arch::uint8x16x4_t, distribute4::<_, 64, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x4, vld1q_s8_x4, i8, arch::int8x16x4_t, distribute4::<_, 64, 16>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x4, vld1q_u16_x4, u16, arch::uint16x8x4_t, distribute4::<_, 32, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x4, vld1q_s16_x4, i16, arch::int16x8x4_t, distribute4::<_, 32, 8>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x4, vld1q_u32_x4, u32, arch::uint32x4x4_t, distribute4::<_, 16, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x4, vld1q_s32_x4, i32, arch::int32x4x4_t, distribute4::<_, 16, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x4, vld1q_f32_x4, f32, arch::float32x4x4_t, distribute4::<_, 16, 4>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x4, vld1q_u64_x4, u64, arch::uint64x2x4_t, distribute4::<_, 8, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x4, vld1q_s64_x4, i64, arch::int64x2x4_t, distribute4::<_, 8, 2>);
-    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x4, vld1q_f64_x4, f64, arch::float64x2x4_t, distribute4::<_, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x4, vld1q_u8_x4, u8, arch::uint8x16x4_t, as_chunks::<_, 4, 64, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x4, vld1q_s8_x4, i8, arch::int8x16x4_t, as_chunks::<_, 4, 64, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x4, vld1q_u16_x4, u16, arch::uint16x8x4_t, as_chunks::<_, 4, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x4, vld1q_s16_x4, i16, arch::int16x8x4_t, as_chunks::<_, 4, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x4, vld1q_u32_x4, u32, arch::uint32x4x4_t, as_chunks::<_, 4, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x4, vld1q_s32_x4, i32, arch::int32x4x4_t, as_chunks::<_, 4, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x4, vld1q_f32_x4, f32, arch::float32x4x4_t, as_chunks::<_, 4, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x4, vld1q_u64_x4, u64, arch::uint64x2x4_t, as_chunks::<_, 4, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x4, vld1q_s64_x4, i64, arch::int64x2x4_t, as_chunks::<_, 4, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x4, vld1q_f64_x4, f64, arch::float64x2x4_t, as_chunks::<_, 4, 8, 2>);
 
     // Generate a test for an intrinsic. The primary use of tests is that they execute under Miri,
     // which eliminates most forms of type confusion we could have inadvertently introduced by
     // mismatching intrinsic types and exposed memory types. The syntax for this macro also formats
     // more consistently under rustfmt (one line each).
+    //
+    // Safety: `base` must be a Pod (integer) type and `ty` must be a SIMD vector type
     macro_rules! test_vst1_from_slice {
         ($(#[$attr:meta])* fn $testname:ident, $intrinsic:ident, $base:ty, $ty:ty $(, $with:expr)?) => {
             #[test]
@@ -674,10 +675,17 @@ mod tests {
             $(#[$attr])*
             fn $testname() {
                 fn generate<const N: usize>(val: &[$base; N]) -> $ty {
+                    assert!(core::mem::size_of::<$ty>() == core::mem::size_of::<[$base; N]>());
+                    // Safety: transmuting array representation to a SIMD vector, both are Pod.
+                    // This can not utilize `transmute` since the size of `val` is polymorphic,
+                    // and the compiler rejects a transmute it can not statically prove to be
+                    // between equivalently sized types, e.g. dependently sized type on `N`.
                     unsafe { core::mem::transmute_copy::<[$base; N], $ty>(val) }
                 }
 
                 fn result_init<T>() -> T {
+                    // Safety: only called on arrays out of `Pod` types. (See use below). This does
+                    // not escape the macro hence only local use must be reviewed.
                     unsafe { core::mem::zeroed() }
                 }
 
@@ -717,47 +725,39 @@ mod tests {
     test_vst1_from_slice!(fn test_vst1_i64, vst1_s64, i64, arch::int64x1_t, |val| [val]);
     test_vst1_from_slice!(fn test_vst1_f64, vst1_f64, f64, arch::float64x1_t, |val| [val]);
 
-    fn gather2<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 2]) -> [T; N] {
+    fn flatten<T: Copy, const L: usize, const N: usize, const M: usize>(v: [[T; M]; L]) -> [T; N] {
         <[T; N]>::try_from(v.as_flattened()).unwrap()
     }
 
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x2, vst1_u8_x2, u8, arch::uint8x8x2_t, gather2::<_, 16, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x2, vst1_s8_x2, i8, arch::int8x8x2_t, gather2::<_, 16, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x2, vst1_u16_x2, u16, arch::uint16x4x2_t, gather2::<_, 8, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x2, vst1_s16_x2, i16, arch::int16x4x2_t, gather2::<_, 8, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x2, vst1_u32_x2, u32, arch::uint32x2x2_t, gather2::<_, 4, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x2, vst1_s32_x2, i32, arch::int32x2x2_t, gather2::<_, 4, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x2, vst1_f32_x2, f32, arch::float32x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x2, vst1_u8_x2, u8, arch::uint8x8x2_t, flatten::<_, 2, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x2, vst1_s8_x2, i8, arch::int8x8x2_t, flatten::<_, 2, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x2, vst1_u16_x2, u16, arch::uint16x4x2_t, flatten::<_, 2, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x2, vst1_s16_x2, i16, arch::int16x4x2_t, flatten::<_, 2, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x2, vst1_u32_x2, u32, arch::uint32x2x2_t, flatten::<_, 2, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x2, vst1_s32_x2, i32, arch::int32x2x2_t, flatten::<_, 2, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x2, vst1_f32_x2, f32, arch::float32x2x2_t, flatten::<_, 2, 4, 2>);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x2, vst1_u64_x2, u64, arch::uint64x1x2_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x2, vst1_s64_x2, i64, arch::int64x1x2_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x2, vst1_f64_x2, f64, arch::float64x1x2_t);
 
-    fn gather3<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 3]) -> [T; N] {
-        <[T; N]>::try_from(v.as_flattened()).unwrap()
-    }
-
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x3, vst1_u8_x3, u8, arch::uint8x8x3_t, gather3::<_, 24, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x3, vst1_s8_x3, i8, arch::int8x8x3_t, gather3::<_, 24, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x3, vst1_u16_x3, u16, arch::uint16x4x3_t, gather3::<_, 12, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x3, vst1_s16_x3, i16, arch::int16x4x3_t, gather3::<_, 12, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x3, vst1_u32_x3, u32, arch::uint32x2x3_t, gather3::<_, 6, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x3, vst1_s32_x3, i32, arch::int32x2x3_t, gather3::<_, 6, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x3, vst1_f32_x3, f32, arch::float32x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x3, vst1_u8_x3, u8, arch::uint8x8x3_t, flatten::<_, 3, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x3, vst1_s8_x3, i8, arch::int8x8x3_t, flatten::<_, 3, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x3, vst1_u16_x3, u16, arch::uint16x4x3_t, flatten::<_, 3, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x3, vst1_s16_x3, i16, arch::int16x4x3_t, flatten::<_, 3, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x3, vst1_u32_x3, u32, arch::uint32x2x3_t, flatten::<_, 3, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x3, vst1_s32_x3, i32, arch::int32x2x3_t, flatten::<_, 3, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x3, vst1_f32_x3, f32, arch::float32x2x3_t, flatten::<_, 3, 6, 2>);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x3, vst1_u64_x3, u64, arch::uint64x1x3_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x3, vst1_s64_x3, i64, arch::int64x1x3_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x3, vst1_f64_x3, f64, arch::float64x1x3_t);
 
-    fn gather4<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 4]) -> [T; N] {
-        <[T; N]>::try_from(v.as_flattened()).unwrap()
-    }
-
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x4, vst1_u8_x4, u8, arch::uint8x8x4_t, gather4::<_, 32, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x4, vst1_s8_x4, i8, arch::int8x8x4_t, gather4::<_, 32, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x4, vst1_u16_x4, u16, arch::uint16x4x4_t, gather4::<_, 16, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x4, vst1_s16_x4, i16, arch::int16x4x4_t, gather4::<_, 16, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x4, vst1_u32_x4, u32, arch::uint32x2x4_t, gather4::<_, 8, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x4, vst1_s32_x4, i32, arch::int32x2x4_t, gather4::<_, 8, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x4, vst1_f32_x4, f32, arch::float32x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x4, vst1_u8_x4, u8, arch::uint8x8x4_t, flatten::<_, 4, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x4, vst1_s8_x4, i8, arch::int8x8x4_t, flatten::<_, 4, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x4, vst1_u16_x4, u16, arch::uint16x4x4_t, flatten::<_, 4, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x4, vst1_s16_x4, i16, arch::int16x4x4_t, flatten::<_, 4, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x4, vst1_u32_x4, u32, arch::uint32x2x4_t, flatten::<_, 4, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x4, vst1_s32_x4, i32, arch::int32x2x4_t, flatten::<_, 4, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x4, vst1_f32_x4, f32, arch::float32x2x4_t, flatten::<_, 4, 8, 2>);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x4, vst1_u64_x4, u64, arch::uint64x1x4_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x4, vst1_s64_x4, i64, arch::int64x1x4_t);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x4, vst1_f64_x4, f64, arch::float64x1x4_t);
@@ -773,36 +773,36 @@ mod tests {
     test_vst1_from_slice!(fn test_vst1q_i64, vst1q_s64, i64, arch::int64x2_t);
     test_vst1_from_slice!(fn test_vst1q_f64, vst1q_f64, f64, arch::float64x2_t);
 
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x2, vst1q_u8_x2, u8, arch::uint8x16x2_t, gather2::<_, 32, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x2, vst1q_s8_x2, i8, arch::int8x16x2_t, gather2::<_, 32, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x2, vst1q_u16_x2, u16, arch::uint16x8x2_t, gather2::<_, 16, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x2, vst1q_s16_x2, i16, arch::int16x8x2_t, gather2::<_, 16, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x2, vst1q_u32_x2, u32, arch::uint32x4x2_t, gather2::<_, 8, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x2, vst1q_s32_x2, i32, arch::int32x4x2_t, gather2::<_, 8, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x2, vst1q_f32_x2, f32, arch::float32x4x2_t, gather2::<_, 8, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x2, vst1q_u64_x2, u64, arch::uint64x2x2_t, gather2::<_, 4, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x2, vst1q_s64_x2, i64, arch::int64x2x2_t, gather2::<_, 4, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x2, vst1q_f64_x2, f64, arch::float64x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x2, vst1q_u8_x2, u8, arch::uint8x16x2_t, flatten::<_, 2, 32, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x2, vst1q_s8_x2, i8, arch::int8x16x2_t, flatten::<_, 2, 32, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x2, vst1q_u16_x2, u16, arch::uint16x8x2_t, flatten::<_, 2, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x2, vst1q_s16_x2, i16, arch::int16x8x2_t, flatten::<_, 2, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x2, vst1q_u32_x2, u32, arch::uint32x4x2_t, flatten::<_, 2, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x2, vst1q_s32_x2, i32, arch::int32x4x2_t, flatten::<_, 2, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x2, vst1q_f32_x2, f32, arch::float32x4x2_t, flatten::<_, 2, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x2, vst1q_u64_x2, u64, arch::uint64x2x2_t, flatten::<_, 2, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x2, vst1q_s64_x2, i64, arch::int64x2x2_t, flatten::<_, 2, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x2, vst1q_f64_x2, f64, arch::float64x2x2_t, flatten::<_, 2, 4, 2>);
 
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x3, vst1q_u8_x3, u8, arch::uint8x16x3_t, gather3::<_, 48, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x3, vst1q_s8_x3, i8, arch::int8x16x3_t, gather3::<_, 48, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x3, vst1q_u16_x3, u16, arch::uint16x8x3_t, gather3::<_, 24, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x3, vst1q_s16_x3, i16, arch::int16x8x3_t, gather3::<_, 24, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x3, vst1q_u32_x3, u32, arch::uint32x4x3_t, gather3::<_, 12, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x3, vst1q_s32_x3, i32, arch::int32x4x3_t, gather3::<_, 12, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x3, vst1q_f32_x3, f32, arch::float32x4x3_t, gather3::<_, 12, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x3, vst1q_u64_x3, u64, arch::uint64x2x3_t, gather3::<_, 6, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x3, vst1q_s64_x3, i64, arch::int64x2x3_t, gather3::<_, 6, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x3, vst1q_f64_x3, f64, arch::float64x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x3, vst1q_u8_x3, u8, arch::uint8x16x3_t, flatten::<_, 3, 48, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x3, vst1q_s8_x3, i8, arch::int8x16x3_t, flatten::<_, 3, 48, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x3, vst1q_u16_x3, u16, arch::uint16x8x3_t, flatten::<_, 3, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x3, vst1q_s16_x3, i16, arch::int16x8x3_t, flatten::<_, 3, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x3, vst1q_u32_x3, u32, arch::uint32x4x3_t, flatten::<_, 3, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x3, vst1q_s32_x3, i32, arch::int32x4x3_t, flatten::<_, 3, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x3, vst1q_f32_x3, f32, arch::float32x4x3_t, flatten::<_, 3, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x3, vst1q_u64_x3, u64, arch::uint64x2x3_t, flatten::<_, 3, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x3, vst1q_s64_x3, i64, arch::int64x2x3_t, flatten::<_, 3, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x3, vst1q_f64_x3, f64, arch::float64x2x3_t, flatten::<_, 3, 6, 2>);
 
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x4, vst1q_u8_x4, u8, arch::uint8x16x4_t, gather4::<_, 64, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x4, vst1q_s8_x4, i8, arch::int8x16x4_t, gather4::<_, 64, 16>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x4, vst1q_u16_x4, u16, arch::uint16x8x4_t, gather4::<_, 32, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x4, vst1q_s16_x4, i16, arch::int16x8x4_t, gather4::<_, 32, 8>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x4, vst1q_u32_x4, u32, arch::uint32x4x4_t, gather4::<_, 16, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x4, vst1q_s32_x4, i32, arch::int32x4x4_t, gather4::<_, 16, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x4, vst1q_f32_x4, f32, arch::float32x4x4_t, gather4::<_, 16, 4>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x4, vst1q_u64_x4, u64, arch::uint64x2x4_t, gather4::<_, 8, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x4, vst1q_s64_x4, i64, arch::int64x2x4_t, gather4::<_, 8, 2>);
-    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x4, vst1q_f64_x4, f64, arch::float64x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x4, vst1q_u8_x4, u8, arch::uint8x16x4_t, flatten::<_, 4, 64, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x4, vst1q_s8_x4, i8, arch::int8x16x4_t, flatten::<_, 4, 64, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x4, vst1q_u16_x4, u16, arch::uint16x8x4_t, flatten::<_, 4, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x4, vst1q_s16_x4, i16, arch::int16x8x4_t, flatten::<_, 4, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x4, vst1q_u32_x4, u32, arch::uint32x4x4_t, flatten::<_, 4, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x4, vst1q_s32_x4, i32, arch::int32x4x4_t, flatten::<_, 4, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x4, vst1q_f32_x4, f32, arch::float32x4x4_t, flatten::<_, 4, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x4, vst1q_u64_x4, u64, arch::uint64x2x4_t, flatten::<_, 4, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x4, vst1q_s64_x4, i64, arch::int64x2x4_t, flatten::<_, 4, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x4, vst1q_f64_x4, f64, arch::float64x2x4_t, flatten::<_, 4, 8, 2>);
 }

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -500,6 +500,60 @@ vld_n_replicate_k! {
     unsafe: load;
     size: various_sizes;
 
+    /// Load one single-element `i8` and replicate to all lanes.
+    fn vld1_dup_s8(_: &[i8; 1][..1] as i8) -> int8x8_t;
+    /// Load an array of two `i8` elements and replicate to lanes of two registers.
+    fn vld2_dup_s8(_: &[i8; 2][..1] as [i8; 2]) -> int8x8x2_t;
+    /// Load an array of three `i8` elements and replicate to lanes of three registers.
+    fn vld3_dup_s8(_: &[i8; 3][..1] as [i8; 3]) -> int8x8x3_t;
+    /// Load an array of four `i8` elements and replicate to lanes of four registers.
+    fn vld4_dup_s8(_: &[i8; 4][..1] as [i8; 4]) -> int8x8x4_t;
+
+    /// Load one single-element `u8` and replicate to all lanes.
+    fn vld1_dup_u8(_: &[u8; 1][..1] as u8) -> uint8x8_t;
+    /// Load an array of two `u8` elements and replicate to lanes of two registers.
+    fn vld2_dup_u8(_: &[u8; 2][..1] as [u8; 2]) -> uint8x8x2_t;
+    /// Load an array of three `u8` elements and replicate to lanes of three registers.
+    fn vld3_dup_u8(_: &[u8; 3][..1] as [u8; 3]) -> uint8x8x3_t;
+    /// Load an array of four `u8` elements and replicate to lanes of four registers.
+    fn vld4_dup_u8(_: &[u8; 4][..1] as [u8; 4]) -> uint8x8x4_t;
+
+    /// Load one single-element `i16` and replicate to all lanes.
+    fn vld1_dup_s16(_: &[i16; 1][..1] as i16) -> int16x4_t;
+    /// Load an array of two `i16` elements and replicate to lanes of two registers.
+    fn vld2_dup_s16(_: &[i16; 2][..1] as [i16; 2]) -> int16x4x2_t;
+    /// Load an array of three `i16` elements and replicate to lanes of three registers.
+    fn vld3_dup_s16(_: &[i16; 3][..1] as [i16; 3]) -> int16x4x3_t;
+    /// Load an array of four `i16` elements and replicate to lanes of four registers.
+    fn vld4_dup_s16(_: &[i16; 4][..1] as [i16; 4]) -> int16x4x4_t;
+
+    /// Load one single-element `u16` and replicate to all lanes.
+    fn vld1_dup_u16(_: &[u16; 1][..1] as u16) -> uint16x4_t;
+    /// Load an array of two `u16` elements and replicate to lanes of two registers.
+    fn vld2_dup_u16(_: &[u16; 2][..1] as [u16; 2]) -> uint16x4x2_t;
+    /// Load an array of three `u16` elements and replicate to lanes of three registers.
+    fn vld3_dup_u16(_: &[u16; 3][..1] as [u16; 3]) -> uint16x4x3_t;
+    /// Load an array of four `u16` elements and replicate to lanes of four registers.
+    fn vld4_dup_u16(_: &[u16; 4][..1] as [u16; 4]) -> uint16x4x4_t;
+
+    /// Load one single-element `i32` and replicate to all lanes.
+    fn vld1_dup_s32(_: &[i32; 1][..1] as i32) -> int32x2_t;
+    /// Load an array of two `i32` elements and replicate to lanes of two registers.
+    fn vld2_dup_s32(_: &[i32; 2][..1] as [i32; 2]) -> int32x2x2_t;
+    /// Load an array of three `i32` elements and replicate to lanes of three registers.
+    fn vld3_dup_s32(_: &[i32; 3][..1] as [i32; 3]) -> int32x2x3_t;
+    /// Load an array of four `i32` elements and replicate to lanes of four registers.
+    fn vld4_dup_s32(_: &[i32; 4][..1] as [i32; 4]) -> int32x2x4_t;
+
+    /// Load one single-element `u32` and replicate to all lanes.
+    fn vld1_dup_u32(_: &[u32; 1][..1] as u32) -> uint32x2_t;
+    /// Load an array of two `u32` elements and replicate to lanes of two registers.
+    fn vld2_dup_u32(_: &[u32; 2][..1] as [u32; 2]) -> uint32x2x2_t;
+    /// Load an array of three `u32` elements and replicate to lanes of three registers.
+    fn vld3_dup_u32(_: &[u32; 3][..1] as [u32; 3]) -> uint32x2x3_t;
+    /// Load an array of four `u32` elements and replicate to lanes of four registers.
+    fn vld4_dup_u32(_: &[u32; 4][..1] as [u32; 4]) -> uint32x2x4_t;
+
     /// Load one single-element `f32` and replicate to all lanes.
     fn vld1_dup_f32(_: &[f32; 1][..1] as f32) -> float32x2_t;
     /// Load an array of two `f32` elements and replicate to lanes of two registers.
@@ -509,6 +563,24 @@ vld_n_replicate_k! {
     /// Load an array of four `f32` elements and replicate to lanes of four registers.
     fn vld4_dup_f32(_: &[f32; 4][..1] as [f32; 4]) -> float32x2x4_t;
 
+    /// Load one single-element `i64` and replicate to all lanes.
+    fn vld1_dup_s64(_: &[i64; 1][..1] as i64) -> int64x1_t;
+    /// Load an array of two `i64` elements and replicate to lanes of two registers.
+    fn vld2_dup_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x1x2_t;
+    /// Load an array of three `i64` elements and replicate to lanes of three registers.
+    fn vld3_dup_s64(_: &[i64; 3][..1] as [i64; 3]) -> int64x1x3_t;
+    /// Load an array of four `i64` elements and replicate to lanes of four registers.
+    fn vld4_dup_s64(_: &[i64; 4][..1] as [i64; 4]) -> int64x1x4_t;
+
+    /// Load one single-element `u64` and replicate to all lanes.
+    fn vld1_dup_u64(_: &[u64; 1][..1] as u64) -> uint64x1_t;
+    /// Load an array of two `u64` elements and replicate to lanes of two registers.
+    fn vld2_dup_u64(_: &[u64; 2][..1] as [u64; 2]) -> uint64x1x2_t;
+    /// Load an array of three `u64` elements and replicate to lanes of three registers.
+    fn vld3_dup_u64(_: &[u64; 3][..1] as [u64; 3]) -> uint64x1x3_t;
+    /// Load an array of four `u64` elements and replicate to lanes of four registers.
+    fn vld4_dup_u64(_: &[u64; 4][..1] as [u64; 4]) -> uint64x1x4_t;
+
     /// Load one single-element `f64` and replicate to all lanes.
     fn vld1_dup_f64(_: &[f64; 1][..1] as f64) -> float64x1_t;
     /// Load an array of two `f64` elements and replicate to lanes of two registers.
@@ -517,6 +589,65 @@ vld_n_replicate_k! {
     fn vld3_dup_f64(_: &[f64; 3][..1] as [f64; 3]) -> float64x1x3_t;
     /// Load an array of four `f64` elements and replicate to lanes of four registers.
     fn vld4_dup_f64(_: &[f64; 4][..1] as [f64; 4]) -> float64x1x4_t;
+}
+
+vld_n_replicate_k! {
+    unsafe: load;
+    size: various_sizes;
+
+    /// Load one single-element `i8` and replicate to all lanes.
+    fn vld1q_dup_s8(_: &[i8; 1][..1] as i8) -> int8x16_t;
+    /// Load an array of two `i8` elements and replicate to lanes of two registers.
+    fn vld2q_dup_s8(_: &[i8; 2][..1] as [i8; 2]) -> int8x16x2_t;
+    /// Load an array of three `i8` elements and replicate to lanes of three registers.
+    fn vld3q_dup_s8(_: &[i8; 3][..1] as [i8; 3]) -> int8x16x3_t;
+    /// Load an array of four `i8` elements and replicate to lanes of four registers.
+    fn vld4q_dup_s8(_: &[i8; 4][..1] as [i8; 4]) -> int8x16x4_t;
+
+    /// Load one single-element `u8` and replicate to all lanes.
+    fn vld1q_dup_u8(_: &[u8; 1][..1] as u8) -> uint8x16_t;
+    /// Load an array of two `u8` elements and replicate to lanes of two registers.
+    fn vld2q_dup_u8(_: &[u8; 2][..1] as [u8; 2]) -> uint8x16x2_t;
+    /// Load an array of three `u8` elements and replicate to lanes of three registers.
+    fn vld3q_dup_u8(_: &[u8; 3][..1] as [u8; 3]) -> uint8x16x3_t;
+    /// Load an array of four `u8` elements and replicate to lanes of four registers.
+    fn vld4q_dup_u8(_: &[u8; 4][..1] as [u8; 4]) -> uint8x16x4_t;
+
+    /// Load one single-element `i16` and replicate to all lanes.
+    fn vld1q_dup_s16(_: &[i16; 1][..1] as i16) -> int16x8_t;
+    /// Load an array of two `i16` elements and replicate to lanes of two registers.
+    fn vld2q_dup_s16(_: &[i16; 2][..1] as [i16; 2]) -> int16x8x2_t;
+    /// Load an array of three `i16` elements and replicate to lanes of three registers.
+    fn vld3q_dup_s16(_: &[i16; 3][..1] as [i16; 3]) -> int16x8x3_t;
+    /// Load an array of four `i16` elements and replicate to lanes of four registers.
+    fn vld4q_dup_s16(_: &[i16; 4][..1] as [i16; 4]) -> int16x8x4_t;
+
+    /// Load one single-element `u16` and replicate to all lanes.
+    fn vld1q_dup_u16(_: &[u16; 1][..1] as u16) -> uint16x8_t;
+    /// Load an array of two `u16` elements and replicate to lanes of two registers.
+    fn vld2q_dup_u16(_: &[u16; 2][..1] as [u16; 2]) -> uint16x8x2_t;
+    /// Load an array of three `u16` elements and replicate to lanes of three registers.
+    fn vld3q_dup_u16(_: &[u16; 3][..1] as [u16; 3]) -> uint16x8x3_t;
+    /// Load an array of four `u16` elements and replicate to lanes of four registers.
+    fn vld4q_dup_u16(_: &[u16; 4][..1] as [u16; 4]) -> uint16x8x4_t;
+
+    /// Load one single-element `i32` and replicate to all lanes.
+    fn vld1q_dup_s32(_: &[i32; 1][..1] as i32) -> int32x4_t;
+    /// Load an array of two `i32` elements and replicate to lanes of two registers.
+    fn vld2q_dup_s32(_: &[i32; 2][..1] as [i32; 2]) -> int32x4x2_t;
+    /// Load an array of three `i32` elements and replicate to lanes of three registers.
+    fn vld3q_dup_s32(_: &[i32; 3][..1] as [i32; 3]) -> int32x4x3_t;
+    /// Load an array of four `i32` elements and replicate to lanes of four registers.
+    fn vld4q_dup_s32(_: &[i32; 4][..1] as [i32; 4]) -> int32x4x4_t;
+
+    /// Load one single-element `u32` and replicate to all lanes.
+    fn vld1q_dup_u32(_: &[u32; 1][..1] as u32) -> uint32x4_t;
+    /// Load an array of two `u32` elements and replicate to lanes of two registers.
+    fn vld2q_dup_u32(_: &[u32; 2][..1] as [u32; 2]) -> uint32x4x2_t;
+    /// Load an array of three `u32` elements and replicate to lanes of three registers.
+    fn vld3q_dup_u32(_: &[u32; 3][..1] as [u32; 3]) -> uint32x4x3_t;
+    /// Load an array of four `u32` elements and replicate to lanes of four registers.
+    fn vld4q_dup_u32(_: &[u32; 4][..1] as [u32; 4]) -> uint32x4x4_t;
 
     /// Load one single-element `f32` and replicate to all lanes.
     fn vld1q_dup_f32(_: &[f32; 1][..1] as f32) -> float32x4_t;
@@ -526,6 +657,33 @@ vld_n_replicate_k! {
     fn vld3q_dup_f32(_: &[f32; 3][..1] as [f32; 3]) -> float32x4x3_t;
     /// Load an array of four `f32` elements and replicate to lanes of four registers.
     fn vld4q_dup_f32(_: &[f32; 4][..1] as [f32; 4]) -> float32x4x4_t;
+
+    /// Load one single-element `i64` and replicate to all lanes.
+    fn vld1q_dup_s64(_: &[i64; 1][..1] as i64) -> int64x2_t;
+    /// Load an array of two `i64` elements and replicate to lanes of two registers.
+    fn vld2q_dup_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x2x2_t;
+    /// Load an array of three `i64` elements and replicate to lanes of three registers.
+    fn vld3q_dup_s64(_: &[i64; 3][..1] as [i64; 3]) -> int64x2x3_t;
+    /// Load an array of four `i64` elements and replicate to lanes of four registers.
+    fn vld4q_dup_s64(_: &[i64; 4][..1] as [i64; 4]) -> int64x2x4_t;
+
+    /// Load one single-element `u64` and replicate to all lanes.
+    fn vld1q_dup_u64(_: &[u64; 1][..1] as u64) -> uint64x2_t;
+    /// Load an array of two `u64` elements and replicate to lanes of two registers.
+    fn vld2q_dup_u64(_: &[u64; 2][..1] as [u64; 2]) -> uint64x2x2_t;
+    /// Load an array of three `u64` elements and replicate to lanes of three registers.
+    fn vld3q_dup_u64(_: &[u64; 3][..1] as [u64; 3]) -> uint64x2x3_t;
+    /// Load an array of four `u64` elements and replicate to lanes of four registers.
+    fn vld4q_dup_u64(_: &[u64; 4][..1] as [u64; 4]) -> uint64x2x4_t;
+
+    /// Load one single-element `f64` and replicate to all lanes.
+    fn vld1q_dup_f64(_: &[f64; 1][..1] as f64) -> float64x2_t;
+    /// Load an array of two `f64` elements and replicate to lanes of two registers.
+    fn vld2q_dup_f64(_: &[f64; 2][..1] as [f64; 2]) -> float64x2x2_t;
+    /// Load an array of three `f64` elements and replicate to lanes of three registers.
+    fn vld3q_dup_f64(_: &[f64; 3][..1] as [f64; 3]) -> float64x2x3_t;
+    /// Load an array of four `f64` elements and replicate to lanes of four registers.
+    fn vld4q_dup_f64(_: &[f64; 4][..1] as [f64; 4]) -> float64x2x4_t;
 }
 
 #[cfg(test)]
@@ -581,7 +739,9 @@ mod tests {
     test_vld1_from_slice!(fn test_vld1_i64, vld1_s64, i64, arch::int64x1_t, |[val]: [_; 1]| val);
     test_vld1_from_slice!(fn test_vld1_f64, vld1_f64, f64, arch::float64x1_t, |[val]: [_; 1]| val);
 
-    fn as_chunks<T: Copy, const L: usize, const N: usize, const M: usize>(v: [T; N]) -> [[T; M]; L] {
+    fn as_chunks<T: Copy, const L: usize, const N: usize, const M: usize>(
+        v: [T; N],
+    ) -> [[T; M]; L] {
         <[[T; M]; L]>::try_from(v.as_chunks::<M>().0).unwrap()
     }
 
@@ -805,4 +965,193 @@ mod tests {
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x4, vst1q_u64_x4, u64, arch::uint64x2x4_t, flatten::<_, 4, 8, 2>);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x4, vst1q_s64_x4, i64, arch::int64x2x4_t, flatten::<_, 4, 8, 2>);
     test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x4, vst1q_f64_x4, f64, arch::float64x2x4_t, flatten::<_, 4, 8, 2>);
+
+    macro_rules! test_vldup {
+        // The *dup* family is always 4 different functions so let's do them in one macro call.
+        ($(#[$attr:meta])*
+         fn [$test1:ident, $test2:ident, $test3:ident, $test4:ident],
+            [$intr1:ident, $intr2:ident, $intr3:ident, $intr4:ident],
+            $base:ty,
+            [$ty1:ty, $ty2:ty, $ty3:ty, $ty4:ty]
+        ) => {
+            test_vldup!(@$(#[$attr])* fn ([$test1], [$intr1], $base, [$ty1], 1) => |c| &c[0]);
+            test_vldup!(@$(#[$attr])* #[cfg_attr(miri, ignore)] fn ([$test2], [$intr2], $base, [$ty2], 2) => |c| &c);
+            test_vldup!(@$(#[$attr])* #[cfg_attr(miri, ignore)] fn ([$test3], [$intr3], $base, [$ty3], 3) => |c| &c);
+            test_vldup!(@$(#[$attr])* #[cfg_attr(miri, ignore)] fn ([$test4], [$intr4], $base, [$ty4], 4) => |c| &c);
+        };
+
+        (@$(#[$attr:meta])* fn ([$test1:ident], [$intr1:ident], $base:ty, [$ty1:ty], $n:expr)
+         => |$arr:ident| $extract:expr) => {
+            #[test]
+            #[cfg(target_feature = "neon")]
+            $(#[$attr])*
+            fn $test1() {
+                fn assert_chunks(val: $ty1, expected: [$base; $n]) {
+                    const S: usize = size_of::<$ty1>() / size_of::<$base>();
+                    const V: usize = S / $n;
+
+                    // Transmute between vector register and its array representation.
+                    let val = unsafe { ::core::mem::transmute::<$ty1, [$base; S]>(val) };
+
+                    for (data, &expected) in val.chunks_exact(V).zip(&expected) {
+                        let expected: [$base; V] = [expected; V];
+                        assert_eq!(data, expected);
+                    }
+                }
+
+                #[target_feature(enable = "neon")]
+                fn test() {
+                    let $arr: [$base; $n] = core::array::from_fn(|i| 0x42 as $base + i as $base);
+                    let v = super::$intr1($extract);
+                    assert_chunks(v, $arr);
+                }
+
+                unsafe { test() }
+            }
+        };
+    }
+
+    // 8-byte vector variants of dup.
+
+    test_vldup!(
+        fn [test_vld1_dup_s8, test_vld2_dup_s8, test_vld3_dup_s8, test_vld4_dup_s8],
+           [vld1_dup_s8, vld2_dup_s8, vld3_dup_s8, vld4_dup_s8],
+           i8,
+           [arch::int8x8_t, arch::int8x8x2_t, arch::int8x8x3_t, arch::int8x8x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_u8, test_vld2_dup_u8, test_vld3_dup_u8, test_vld4_dup_u8],
+           [vld1_dup_u8, vld2_dup_u8, vld3_dup_u8, vld4_dup_u8],
+           u8,
+           [arch::uint8x8_t, arch::uint8x8x2_t, arch::uint8x8x3_t, arch::uint8x8x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_s16, test_vld2_dup_s16, test_vld3_dup_s16, test_vld4_dup_s16],
+           [vld1_dup_s16, vld2_dup_s16, vld3_dup_s16, vld4_dup_s16],
+           i16,
+           [arch::int16x4_t, arch::int16x4x2_t, arch::int16x4x3_t, arch::int16x4x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_u16, test_vld2_dup_u16, test_vld3_dup_u16, test_vld4_dup_u16],
+           [vld1_dup_u16, vld2_dup_u16, vld3_dup_u16, vld4_dup_u16],
+           u16,
+           [arch::uint16x4_t, arch::uint16x4x2_t, arch::uint16x4x3_t, arch::uint16x4x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_s32, test_vld2_dup_s32, test_vld3_dup_s32, test_vld4_dup_s32],
+           [vld1_dup_s32, vld2_dup_s32, vld3_dup_s32, vld4_dup_s32],
+           i32,
+           [arch::int32x2_t, arch::int32x2x2_t, arch::int32x2x3_t, arch::int32x2x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_u32, test_vld2_dup_u32, test_vld3_dup_u32, test_vld4_dup_u32],
+           [vld1_dup_u32, vld2_dup_u32, vld3_dup_u32, vld4_dup_u32],
+           u32,
+           [arch::uint32x2_t, arch::uint32x2x2_t, arch::uint32x2x3_t, arch::uint32x2x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_f32, test_vld2_dup_f32, test_vld3_dup_f32, test_vld4_dup_f32],
+           [vld1_dup_f32, vld2_dup_f32, vld3_dup_f32, vld4_dup_f32],
+           f32,
+           [arch::float32x2_t, arch::float32x2x2_t, arch::float32x2x3_t, arch::float32x2x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_s64, test_vld2_dup_s64, test_vld3_dup_s64, test_vld4_dup_s64],
+           [vld1_dup_s64, vld2_dup_s64, vld3_dup_s64, vld4_dup_s64],
+           i64,
+           [arch::int64x1_t, arch::int64x1x2_t, arch::int64x1x3_t, arch::int64x1x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_u64, test_vld2_dup_u64, test_vld3_dup_u64, test_vld4_dup_u64],
+           [vld1_dup_u64, vld2_dup_u64, vld3_dup_u64, vld4_dup_u64],
+           u64,
+           [arch::uint64x1_t, arch::uint64x1x2_t, arch::uint64x1x3_t, arch::uint64x1x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1_dup_f64, test_vld2_dup_f64, test_vld3_dup_f64, test_vld4_dup_f64],
+           [vld1_dup_f64, vld2_dup_f64, vld3_dup_f64, vld4_dup_f64],
+           f64,
+           [arch::float64x1_t, arch::float64x1x2_t, arch::float64x1x3_t, arch::float64x1x4_t]
+    );
+
+    // 16-byte vector variants of dup.
+
+    test_vldup!(
+        fn [test_vld1q_dup_s8, test_vld2q_dup_s8, test_vld3q_dup_s8, test_vld4q_dup_s8],
+           [vld1q_dup_s8, vld2q_dup_s8, vld3q_dup_s8, vld4q_dup_s8],
+           i8,
+           [arch::int8x16_t, arch::int8x16x2_t, arch::int8x16x3_t, arch::int8x16x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_u8, test_vld2q_dup_u8, test_vld3q_dup_u8, test_vld4q_dup_u8],
+           [vld1q_dup_u8, vld2q_dup_u8, vld3q_dup_u8, vld4q_dup_u8],
+           u8,
+           [arch::uint8x16_t, arch::uint8x16x2_t, arch::uint8x16x3_t, arch::uint8x16x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_s16, test_vld2q_dup_s16, test_vld3q_dup_s16, test_vld4q_dup_s16],
+           [vld1q_dup_s16, vld2q_dup_s16, vld3q_dup_s16, vld4q_dup_s16],
+           i16,
+           [arch::int16x8_t, arch::int16x8x2_t, arch::int16x8x3_t, arch::int16x8x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_u16, test_vld2q_dup_u16, test_vld3q_dup_u16, test_vld4q_dup_u16],
+           [vld1q_dup_u16, vld2q_dup_u16, vld3q_dup_u16, vld4q_dup_u16],
+           u16,
+           [arch::uint16x8_t, arch::uint16x8x2_t, arch::uint16x8x3_t, arch::uint16x8x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_s32, test_vld2q_dup_s32, test_vld3q_dup_s32, test_vld4q_dup_s32],
+           [vld1q_dup_s32, vld2q_dup_s32, vld3q_dup_s32, vld4q_dup_s32],
+           i32,
+           [arch::int32x4_t, arch::int32x4x2_t, arch::int32x4x3_t, arch::int32x4x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_u32, test_vld2q_dup_u32, test_vld3q_dup_u32, test_vld4q_dup_u32],
+           [vld1q_dup_u32, vld2q_dup_u32, vld3q_dup_u32, vld4q_dup_u32],
+           u32,
+           [arch::uint32x4_t, arch::uint32x4x2_t, arch::uint32x4x3_t, arch::uint32x4x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_f32, test_vld2q_dup_f32, test_vld3q_dup_f32, test_vld4q_dup_f32],
+           [vld1q_dup_f32, vld2q_dup_f32, vld3q_dup_f32, vld4q_dup_f32],
+           f32,
+           [arch::float32x4_t, arch::float32x4x2_t, arch::float32x4x3_t, arch::float32x4x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_s64, test_vld2q_dup_s64, test_vld3q_dup_s64, test_vld4q_dup_s64],
+           [vld1q_dup_s64, vld2q_dup_s64, vld3q_dup_s64, vld4q_dup_s64],
+           i64,
+           [arch::int64x2_t, arch::int64x2x2_t, arch::int64x2x3_t, arch::int64x2x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_u64, test_vld2q_dup_u64, test_vld3q_dup_u64, test_vld4q_dup_u64],
+           [vld1q_dup_u64, vld2q_dup_u64, vld3q_dup_u64, vld4q_dup_u64],
+           u64,
+           [arch::uint64x2_t, arch::uint64x2x2_t, arch::uint64x2x3_t, arch::uint64x2x4_t]
+    );
+
+    test_vldup!(
+        fn [test_vld1q_dup_f64, test_vld2q_dup_f64, test_vld3q_dup_f64, test_vld4q_dup_f64],
+           [vld1q_dup_f64, vld2q_dup_f64, vld3q_dup_f64, vld4q_dup_f64],
+           f64,
+           [arch::float64x2_t, arch::float64x2x2_t, arch::float64x2x3_t, arch::float64x2x4_t]
+    );
 }

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -318,7 +318,7 @@ vld_n_replicate_k! {
 
 vld_n_replicate_k! {
     unsafe: store;
-    // Loads full registers, so 8 bytes per register
+    // Stores full registers, so 8 bytes per register
     size: assert_size_8bytes;
 
     /// Store an array of 8 `u8` values from one 8-byte register.
@@ -408,7 +408,7 @@ vld_n_replicate_k! {
 
 vld_n_replicate_k! {
     unsafe: store;
-    // Loads full registers, so 16 bytes per register
+    // Stores full registers, so 16 bytes per register
     size: assert_size_16bytes;
 
     /// Store an array of 16 `u8` values to one 16-byte register.

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -251,6 +251,159 @@ vld_n_replicate_k! {
     fn vld1q_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x2_t;
     /// load an array of 2 `f64` value to one 16-byte register.
     fn vld1q_f64(_: &[f64; 2][..1] as [f64; 2]) -> float64x2_t;
+
+    /// load two arrays of 16 `u8` values to two 16-byte registers.
+    fn vld1q_u8_x2(_: &[u8; 16][..2] as [[u8; 16]; 2]) -> uint8x16x2_t;
+    /// load two arrays of 16 `i8` values to two 16-byte registers.
+    fn vld1q_s8_x2(_: &[i8; 16][..2] as [[i8; 16]; 2]) -> int8x16x2_t;
+    /// load two arrays of 8 `i16` values to two 16-byte registers.
+    fn vld1q_u16_x2(_: &[u16; 8][..2] as [[u16; 8]; 2]) -> uint16x8x2_t;
+    /// load two arrays of 8 `u16` values to two 16-byte registers.
+    fn vld1q_s16_x2(_: &[i16; 8][..2] as [[i16; 8]; 2]) -> int16x8x2_t;
+    /// load two arrays of 4 `u32` values to two 16-byte registers.
+    fn vld1q_u32_x2(_: &[u32; 4][..2] as [[u32; 4]; 2]) -> uint32x4x2_t;
+    /// load two arrays of 4 `i32` values to two 16-byte registers.
+    fn vld1q_s32_x2(_: &[i32; 4][..2] as [[i32; 4]; 2]) -> int32x4x2_t;
+    /// load two arrays of 4 `f32` values to two 16-byte registers.
+    fn vld1q_f32_x2(_: &[f32; 4][..2] as [[f32; 4]; 2]) -> float32x4x2_t;
+    /// load two arrays of 2 `u64` value to two 16-byte registers.
+    fn vld1q_u64_x2(_: &[u64; 2][..2] as [[u64; 2]; 2]) -> uint64x2x2_t;
+    /// load two arrays of 2 `i64` value to two 16-byte registers.
+    fn vld1q_s64_x2(_: &[i64; 2][..2] as [[i64; 2]; 2]) -> int64x2x2_t;
+    /// load two arrays of 2 `f64` value to two 16-byte registers.
+    fn vld1q_f64_x2(_: &[f64; 2][..2] as [[f64; 2]; 2]) -> float64x2x2_t;
+
+    /// load three arrays of 16 `u8` values to three16-byte registers.
+    fn vld1q_u8_x3(_: &[u8; 16][..3] as [[u8; 16]; 3]) -> uint8x16x3_t;
+    /// load three arrays of 16 `i8` values to three16-byte registers.
+    fn vld1q_s8_x3(_: &[i8; 16][..3] as [[i8; 16]; 3]) -> int8x16x3_t;
+    /// load three arrays of 8 `i16` values to three16-byte registers.
+    fn vld1q_u16_x3(_: &[u16; 8][..3] as [[u16; 8]; 3]) -> uint16x8x3_t;
+    /// load three arrays of 8 `u16` values to three16-byte registers.
+    fn vld1q_s16_x3(_: &[i16; 8][..3] as [[i16; 8]; 3]) -> int16x8x3_t;
+    /// load three arrays of 4 `u32` values to three16-byte registers.
+    fn vld1q_u32_x3(_: &[u32; 4][..3] as [[u32; 4]; 3]) -> uint32x4x3_t;
+    /// load three arrays of 4 `i32` values to three16-byte registers.
+    fn vld1q_s32_x3(_: &[i32; 4][..3] as [[i32; 4]; 3]) -> int32x4x3_t;
+    /// load three arrays of 4 `f32` values to three16-byte registers.
+    fn vld1q_f32_x3(_: &[f32; 4][..3] as [[f32; 4]; 3]) -> float32x4x3_t;
+    /// load three arrays of 2 `u64` value to three16-byte registers.
+    fn vld1q_u64_x3(_: &[u64; 2][..3] as [[u64; 2]; 3]) -> uint64x2x3_t;
+    /// load three arrays of 2 `i64` value to three16-byte registers.
+    fn vld1q_s64_x3(_: &[i64; 2][..3] as [[i64; 2]; 3]) -> int64x2x3_t;
+    /// load three arrays of 2 `f64` value to three16-byte registers.
+    fn vld1q_f64_x3(_: &[f64; 2][..3] as [[f64; 2]; 3]) -> float64x2x3_t;
+
+    /// load four arrays of 16 `u8` values to four 16-byte registers.
+    fn vld1q_u8_x4(_: &[u8; 16][..4] as [[u8; 16]; 4]) -> uint8x16x4_t;
+    /// load four arrays of 16 `i8` values to four 16-byte registers.
+    fn vld1q_s8_x4(_: &[i8; 16][..4] as [[i8; 16]; 4]) -> int8x16x4_t;
+    /// load four arrays of 8 `i16` values to four 16-byte registers.
+    fn vld1q_u16_x4(_: &[u16; 8][..4] as [[u16; 8]; 4]) -> uint16x8x4_t;
+    /// load four arrays of 8 `u16` values to four 16-byte registers.
+    fn vld1q_s16_x4(_: &[i16; 8][..4] as [[i16; 8]; 4]) -> int16x8x4_t;
+    /// load four arrays of 4 `u32` values to four 16-byte registers.
+    fn vld1q_u32_x4(_: &[u32; 4][..4] as [[u32; 4]; 4]) -> uint32x4x4_t;
+    /// load four arrays of 4 `i32` values to four 16-byte registers.
+    fn vld1q_s32_x4(_: &[i32; 4][..4] as [[i32; 4]; 4]) -> int32x4x4_t;
+    /// load four arrays of 4 `f32` values to four 16-byte registers.
+    fn vld1q_f32_x4(_: &[f32; 4][..4] as [[f32; 4]; 4]) -> float32x4x4_t;
+    /// load four arrays of 2 `u64` value to four 16-byte registers.
+    fn vld1q_u64_x4(_: &[u64; 2][..4] as [[u64; 2]; 4]) -> uint64x2x4_t;
+    /// load four arrays of 2 `i64` value to four 16-byte registers.
+    fn vld1q_s64_x4(_: &[i64; 2][..4] as [[i64; 2]; 4]) -> int64x2x4_t;
+    /// load four arrays of 2 `f64` value to four 16-byte registers.
+    fn vld1q_f64_x4(_: &[f64; 2][..4] as [[f64; 2]; 4]) -> float64x2x4_t;
+}
+
+vld_n_replicate_k! {
+    unsafe: store;
+    // Loads full registers, so 16 bytes per register
+    size: assert_size_8bytes;
+
+    /// store an array of 8 `u8` values from one 8-byte register.
+    fn vst1_u8(_: &[u8; 8][..1] as [u8; 8]) -> uint8x8_t;
+    /// store an array of 8 `i8` values from one 8-byte register.
+    fn vst1_s8(_: &[i8; 8][..1] as [i8; 8]) -> int8x8_t;
+    /// store an array of 4 `i16` values from one 8-byte register.
+    fn vst1_u16(_: &[u16; 4][..1] as [u16; 4]) -> uint16x4_t;
+    /// store an array of 4 `u16` values from one 8-byte register.
+    fn vst1_s16(_: &[i16; 4][..1] as [i16; 4]) -> int16x4_t;
+    /// store an array of 2 `u32` values from one 8-byte register.
+    fn vst1_u32(_: &[u32; 2][..1] as [u32; 2]) -> uint32x2_t;
+    /// store an array of 2 `i32` values from one 8-byte register.
+    fn vst1_s32(_: &[i32; 2][..1] as [i32; 2]) -> int32x2_t;
+    /// store an array of 2 `f32` values from one 8-byte register.
+    fn vst1_f32(_: &[f32; 2][..1] as [f32; 2]) -> float32x2_t;
+    /// store one `u64` value from one 8-byte register.
+    fn vst1_u64(_: &[u64; 1][..1] as u64) -> uint64x1_t;
+    /// store one `i64` value from one 8-byte register.
+    fn vst1_s64(_: &[i64; 1][..1] as i64) -> int64x1_t;
+    /// store one `f64` value from one 8-byte register.
+    fn vst1_f64(_: &[f64; 1][..1] as f64) -> float64x1_t;
+
+    /// store arrays of 8 `u8` values from two 8-byte registers.
+    fn vst1_u8_x2(_: &[u8; 8][..2] as [[u8; 8]; 2]) -> uint8x8x2_t;
+    /// store arrays of 8 `i8` values from two 8-byte registers.
+    fn vst1_s8_x2(_: &[i8; 8][..2] as [[i8; 8]; 2]) -> int8x8x2_t;
+    /// store arrays of 4 `i16` values from two 8-byte registers.
+    fn vst1_u16_x2(_: &[u16; 4][..2] as [[u16; 4]; 2]) -> uint16x4x2_t;
+    /// store arrays of 4 `u16` values from two 8-byte registers.
+    fn vst1_s16_x2(_: &[i16; 4][..2] as [[i16; 4]; 2]) -> int16x4x2_t;
+    /// store arrays of 2 `u32` values from two 8-byte registers.
+    fn vst1_u32_x2(_: &[u32; 2][..2] as [[u32; 2]; 2]) -> uint32x2x2_t;
+    /// store arrays of 2 `i32` values from two 8-byte registers.
+    fn vst1_s32_x2(_: &[i32; 2][..2] as [[i32; 2]; 2]) -> int32x2x2_t;
+    /// store arrays of 2 `f32` values from two 8-byte registers.
+    fn vst1_f32_x2(_: &[f32; 2][..2] as [[f32; 2]; 2]) -> float32x2x2_t;
+    /// store two `u64` values from two 8-byte registers.
+    fn vst1_u64_x2(_: &[u64; 1][..2] as [u64; 2]) -> uint64x1x2_t;
+    /// store two `i64` values from two 8-byte registers.
+    fn vst1_s64_x2(_: &[i64; 1][..2] as [i64; 2]) -> int64x1x2_t;
+    /// store two `f64` values from two 8-byte registers.
+    fn vst1_f64_x2(_: &[f64; 1][..2] as [f64; 2]) -> float64x1x2_t;
+
+    /// store arrays of 8 `u8` values from three 8-byte registers.
+    fn vst1_u8_x3(_: &[u8; 8][..3] as [[u8; 8]; 3]) -> uint8x8x3_t;
+    /// store arrays of 8 `i8` values from three 8-byte registers.
+    fn vst1_s8_x3(_: &[i8; 8][..3] as [[i8; 8]; 3]) -> int8x8x3_t;
+    /// store arrays of 4 `i16` values from three 8-byte registers.
+    fn vst1_u16_x3(_: &[u16; 4][..3] as [[u16; 4]; 3]) -> uint16x4x3_t;
+    /// store arrays of 4 `u16` values from three 8-byte registers.
+    fn vst1_s16_x3(_: &[i16; 4][..3] as [[i16; 4]; 3]) -> int16x4x3_t;
+    /// store arrays of 2 `u32` values from three 8-byte registers.
+    fn vst1_u32_x3(_: &[u32; 2][..3] as [[u32; 2]; 3]) -> uint32x2x3_t;
+    /// store arrays of 2 `i32` values from three 8-byte registers.
+    fn vst1_s32_x3(_: &[i32; 2][..3] as [[i32; 2]; 3]) -> int32x2x3_t;
+    /// store arrays of 2 `f32` values from three 8-byte registers.
+    fn vst1_f32_x3(_: &[f32; 2][..3] as [[f32; 2]; 3]) -> float32x2x3_t;
+    /// store two `u64` values from three 8-byte registers.
+    fn vst1_u64_x3(_: &[u64; 1][..3] as [u64; 3]) -> uint64x1x3_t;
+    /// store two `i64` values from three 8-byte registers.
+    fn vst1_s64_x3(_: &[i64; 1][..3] as [i64; 3]) -> int64x1x3_t;
+    /// store two `f64` values from three 8-byte registers.
+    fn vst1_f64_x3(_: &[f64; 1][..3] as [f64; 3]) -> float64x1x3_t;
+
+    /// store arrays of 8 `u8` values from four 8-byte registers.
+    fn vst1_u8_x4(_: &[u8; 8][..4] as [[u8; 8]; 4]) -> uint8x8x4_t;
+    /// store arrays of 8 `i8` values from four 8-byte registers.
+    fn vst1_s8_x4(_: &[i8; 8][..4] as [[i8; 8]; 4]) -> int8x8x4_t;
+    /// store arrays of 4 `i16` values from four 8-byte registers.
+    fn vst1_u16_x4(_: &[u16; 4][..4] as [[u16; 4]; 4]) -> uint16x4x4_t;
+    /// store arrays of 4 `u16` values from four 8-byte registers.
+    fn vst1_s16_x4(_: &[i16; 4][..4] as [[i16; 4]; 4]) -> int16x4x4_t;
+    /// store arrays of 2 `u32` values from four 8-byte registers.
+    fn vst1_u32_x4(_: &[u32; 2][..4] as [[u32; 2]; 4]) -> uint32x2x4_t;
+    /// store arrays of 2 `i32` values from four 8-byte registers.
+    fn vst1_s32_x4(_: &[i32; 2][..4] as [[i32; 2]; 4]) -> int32x2x4_t;
+    /// store arrays of 2 `f32` values from four 8-byte registers.
+    fn vst1_f32_x4(_: &[f32; 2][..4] as [[f32; 2]; 4]) -> float32x2x4_t;
+    /// store two `u64` values from four 8-byte registers.
+    fn vst1_u64_x4(_: &[u64; 1][..4] as [u64; 4]) -> uint64x1x4_t;
+    /// store two `i64` values from four 8-byte registers.
+    fn vst1_s64_x4(_: &[i64; 1][..4] as [i64; 4]) -> int64x1x4_t;
+    /// store two `f64` values from four 8-byte registers.
+    fn vst1_f64_x4(_: &[f64; 1][..4] as [f64; 4]) -> float64x1x4_t;
 }
 
 vld_n_replicate_k! {
@@ -278,6 +431,69 @@ vld_n_replicate_k! {
     fn vst1q_s64(_: &[i64; 2][..1] as [i64; 2]) -> int64x2_t;
     /// store an array of 2 `f64` value to one 16-byte register.
     fn vst1q_f64(_: &[f64; 2][..1] as [f64; 2]) -> float64x2_t;
+
+    /// store two arrays of 16 `u8` values from two 16-byte registers.
+    fn vst1q_u8_x2(_: &[u8; 16][..2] as [[u8; 16]; 2]) -> uint8x16x2_t;
+    /// store two arrays of 16 `i8` values from two 16-byte registers.
+    fn vst1q_s8_x2(_: &[i8; 16][..2] as [[i8; 16]; 2]) -> int8x16x2_t;
+    /// store two arrays of 8 `i16` values from two 16-byte registers.
+    fn vst1q_u16_x2(_: &[u16; 8][..2] as [[u16; 8]; 2]) -> uint16x8x2_t;
+    /// store two arrays of 8 `u16` values from two 16-byte registers.
+    fn vst1q_s16_x2(_: &[i16; 8][..2] as [[i16; 8]; 2]) -> int16x8x2_t;
+    /// store two arrays of 4 `u32` values from two 16-byte registers.
+    fn vst1q_u32_x2(_: &[u32; 4][..2] as [[u32; 4]; 2]) -> uint32x4x2_t;
+    /// store two arrays of 4 `i32` values from two 16-byte registers.
+    fn vst1q_s32_x2(_: &[i32; 4][..2] as [[i32; 4]; 2]) -> int32x4x2_t;
+    /// store two arrays of 4 `f32` values from two 16-byte registers.
+    fn vst1q_f32_x2(_: &[f32; 4][..2] as [[f32; 4]; 2]) -> float32x4x2_t;
+    /// store two arrays of 2 `u64` value from two 16-byte registers.
+    fn vst1q_u64_x2(_: &[u64; 2][..2] as [[u64; 2]; 2]) -> uint64x2x2_t;
+    /// store two arrays of 2 `i64` value from two 16-byte registers.
+    fn vst1q_s64_x2(_: &[i64; 2][..2] as [[i64; 2]; 2]) -> int64x2x2_t;
+    /// store two arrays of 2 `f64` value from two 16-byte registers.
+    fn vst1q_f64_x2(_: &[f64; 2][..2] as [[f64; 2]; 2]) -> float64x2x2_t;
+
+    /// store three arrays of 16 `u8` values from three16-byte registers.
+    fn vst1q_u8_x3(_: &[u8; 16][..3] as [[u8; 16]; 3]) -> uint8x16x3_t;
+    /// store three arrays of 16 `i8` values from three16-byte registers.
+    fn vst1q_s8_x3(_: &[i8; 16][..3] as [[i8; 16]; 3]) -> int8x16x3_t;
+    /// store three arrays of 8 `i16` values from three16-byte registers.
+    fn vst1q_u16_x3(_: &[u16; 8][..3] as [[u16; 8]; 3]) -> uint16x8x3_t;
+    /// store three arrays of 8 `u16` values from three16-byte registers.
+    fn vst1q_s16_x3(_: &[i16; 8][..3] as [[i16; 8]; 3]) -> int16x8x3_t;
+    /// store three arrays of 4 `u32` values from three16-byte registers.
+    fn vst1q_u32_x3(_: &[u32; 4][..3] as [[u32; 4]; 3]) -> uint32x4x3_t;
+    /// store three arrays of 4 `i32` values from three16-byte registers.
+    fn vst1q_s32_x3(_: &[i32; 4][..3] as [[i32; 4]; 3]) -> int32x4x3_t;
+    /// store three arrays of 4 `f32` values from three16-byte registers.
+    fn vst1q_f32_x3(_: &[f32; 4][..3] as [[f32; 4]; 3]) -> float32x4x3_t;
+    /// store three arrays of 2 `u64` value from three16-byte registers.
+    fn vst1q_u64_x3(_: &[u64; 2][..3] as [[u64; 2]; 3]) -> uint64x2x3_t;
+    /// store three arrays of 2 `i64` value from three16-byte registers.
+    fn vst1q_s64_x3(_: &[i64; 2][..3] as [[i64; 2]; 3]) -> int64x2x3_t;
+    /// store three arrays of 2 `f64` value from three16-byte registers.
+    fn vst1q_f64_x3(_: &[f64; 2][..3] as [[f64; 2]; 3]) -> float64x2x3_t;
+
+    /// store four arrays of 16 `u8` values from four 16-byte registers.
+    fn vst1q_u8_x4(_: &[u8; 16][..4] as [[u8; 16]; 4]) -> uint8x16x4_t;
+    /// store four arrays of 16 `i8` values from four 16-byte registers.
+    fn vst1q_s8_x4(_: &[i8; 16][..4] as [[i8; 16]; 4]) -> int8x16x4_t;
+    /// store four arrays of 8 `i16` values from four 16-byte registers.
+    fn vst1q_u16_x4(_: &[u16; 8][..4] as [[u16; 8]; 4]) -> uint16x8x4_t;
+    /// store four arrays of 8 `u16` values from four 16-byte registers.
+    fn vst1q_s16_x4(_: &[i16; 8][..4] as [[i16; 8]; 4]) -> int16x8x4_t;
+    /// store four arrays of 4 `u32` values from four 16-byte registers.
+    fn vst1q_u32_x4(_: &[u32; 4][..4] as [[u32; 4]; 4]) -> uint32x4x4_t;
+    /// store four arrays of 4 `i32` values from four 16-byte registers.
+    fn vst1q_s32_x4(_: &[i32; 4][..4] as [[i32; 4]; 4]) -> int32x4x4_t;
+    /// store four arrays of 4 `f32` values from four 16-byte registers.
+    fn vst1q_f32_x4(_: &[f32; 4][..4] as [[f32; 4]; 4]) -> float32x4x4_t;
+    /// store four arrays of 2 `u64` value from four 16-byte registers.
+    fn vst1q_u64_x4(_: &[u64; 2][..4] as [[u64; 2]; 4]) -> uint64x2x4_t;
+    /// store four arrays of 2 `i64` value from four 16-byte registers.
+    fn vst1q_s64_x4(_: &[i64; 2][..4] as [[i64; 2]; 4]) -> int64x2x4_t;
+    /// store four arrays of 2 `f64` value from four 16-byte registers.
+    fn vst1q_f64_x4(_: &[f64; 2][..4] as [[f64; 2]; 4]) -> float64x2x4_t;
 }
 
 vld_n_replicate_k! {
@@ -414,6 +630,39 @@ mod tests {
     test_vld1_from_slice!(fn test_vld1q_i64, vld1q_s64, i64, arch::int64x2_t);
     test_vld1_from_slice!(fn test_vld1q_f64, vld1q_f64, f64, arch::float64x2_t);
 
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x2, vld1q_u8_x2, u8, arch::uint8x16x2_t, distribute2::<_, 32, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x2, vld1q_s8_x2, i8, arch::int8x16x2_t, distribute2::<_, 32, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x2, vld1q_u16_x2, u16, arch::uint16x8x2_t, distribute2::<_, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x2, vld1q_s16_x2, i16, arch::int16x8x2_t, distribute2::<_, 16, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x2, vld1q_u32_x2, u32, arch::uint32x4x2_t, distribute2::<_, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x2, vld1q_s32_x2, i32, arch::int32x4x2_t, distribute2::<_, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x2, vld1q_f32_x2, f32, arch::float32x4x2_t, distribute2::<_, 8, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x2, vld1q_u64_x2, u64, arch::uint64x2x2_t, distribute2::<_, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x2, vld1q_s64_x2, i64, arch::int64x2x2_t, distribute2::<_, 4, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x2, vld1q_f64_x2, f64, arch::float64x2x2_t, distribute2::<_, 4, 2>);
+
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x3, vld1q_u8_x3, u8, arch::uint8x16x3_t, distribute3::<_, 48, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x3, vld1q_s8_x3, i8, arch::int8x16x3_t, distribute3::<_, 48, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x3, vld1q_u16_x3, u16, arch::uint16x8x3_t, distribute3::<_, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x3, vld1q_s16_x3, i16, arch::int16x8x3_t, distribute3::<_, 24, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x3, vld1q_u32_x3, u32, arch::uint32x4x3_t, distribute3::<_, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x3, vld1q_s32_x3, i32, arch::int32x4x3_t, distribute3::<_, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x3, vld1q_f32_x3, f32, arch::float32x4x3_t, distribute3::<_, 12, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x3, vld1q_u64_x3, u64, arch::uint64x2x3_t, distribute3::<_, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x3, vld1q_s64_x3, i64, arch::int64x2x3_t, distribute3::<_, 6, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x3, vld1q_f64_x3, f64, arch::float64x2x3_t, distribute3::<_, 6, 2>);
+
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u8_x4, vld1q_u8_x4, u8, arch::uint8x16x4_t, distribute4::<_, 64, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i8_x4, vld1q_s8_x4, i8, arch::int8x16x4_t, distribute4::<_, 64, 16>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u16_x4, vld1q_u16_x4, u16, arch::uint16x8x4_t, distribute4::<_, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i16_x4, vld1q_s16_x4, i16, arch::int16x8x4_t, distribute4::<_, 32, 8>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u32_x4, vld1q_u32_x4, u32, arch::uint32x4x4_t, distribute4::<_, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i32_x4, vld1q_s32_x4, i32, arch::int32x4x4_t, distribute4::<_, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f32_x4, vld1q_f32_x4, f32, arch::float32x4x4_t, distribute4::<_, 16, 4>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_u64_x4, vld1q_u64_x4, u64, arch::uint64x2x4_t, distribute4::<_, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_i64_x4, vld1q_s64_x4, i64, arch::int64x2x4_t, distribute4::<_, 8, 2>);
+    test_vld1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vld1q_f64_x4, vld1q_f64_x4, f64, arch::float64x2x4_t, distribute4::<_, 8, 2>);
+
     // Generate a test for an intrinsic. The primary use of tests is that they execute under Miri,
     // which eliminates most forms of type confusion we could have inadvertently introduced by
     // mismatching intrinsic types and exposed memory types. The syntax for this macro also formats
@@ -428,7 +677,7 @@ mod tests {
                     unsafe { core::mem::transmute_copy::<[$base; N], $ty>(val) }
                 }
 
-                fn result_init<T, const N: usize>() -> [T; N] {
+                fn result_init<T>() -> T {
                     unsafe { core::mem::zeroed() }
                 }
 
@@ -446,7 +695,7 @@ mod tests {
                     super::$intrinsic(&mut result, argument);
 
                     $( // optionally we need to change the type from a flat array.
-                        let ground_truth = $with(source);
+                        let result = $with(result);
                     )?
 
                     assert_eq(&result, &ground_truth);
@@ -456,6 +705,62 @@ mod tests {
             }
         };
     }
+
+    test_vst1_from_slice!(fn test_vst1_u8, vst1_u8, u8, arch::uint8x8_t);
+    test_vst1_from_slice!(fn test_vst1_i8, vst1_s8, i8, arch::int8x8_t);
+    test_vst1_from_slice!(fn test_vst1_u16, vst1_u16, u16, arch::uint16x4_t);
+    test_vst1_from_slice!(fn test_vst1_i16, vst1_s16, i16, arch::int16x4_t);
+    test_vst1_from_slice!(fn test_vst1_u32, vst1_u32, u32, arch::uint32x2_t);
+    test_vst1_from_slice!(fn test_vst1_i32, vst1_s32, i32, arch::int32x2_t);
+    test_vst1_from_slice!(fn test_vst1_f32, vst1_f32, f32, arch::float32x2_t);
+    test_vst1_from_slice!(fn test_vst1_u64, vst1_u64, u64, arch::uint64x1_t, |val| [val]);
+    test_vst1_from_slice!(fn test_vst1_i64, vst1_s64, i64, arch::int64x1_t, |val| [val]);
+    test_vst1_from_slice!(fn test_vst1_f64, vst1_f64, f64, arch::float64x1_t, |val| [val]);
+
+    fn gather2<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 2]) -> [T; N] {
+        <[T; N]>::try_from(v.as_flattened()).unwrap()
+    }
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x2, vst1_u8_x2, u8, arch::uint8x8x2_t, gather2::<_, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x2, vst1_s8_x2, i8, arch::int8x8x2_t, gather2::<_, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x2, vst1_u16_x2, u16, arch::uint16x4x2_t, gather2::<_, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x2, vst1_s16_x2, i16, arch::int16x4x2_t, gather2::<_, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x2, vst1_u32_x2, u32, arch::uint32x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x2, vst1_s32_x2, i32, arch::int32x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x2, vst1_f32_x2, f32, arch::float32x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x2, vst1_u64_x2, u64, arch::uint64x1x2_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x2, vst1_s64_x2, i64, arch::int64x1x2_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x2, vst1_f64_x2, f64, arch::float64x1x2_t);
+
+    fn gather3<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 3]) -> [T; N] {
+        <[T; N]>::try_from(v.as_flattened()).unwrap()
+    }
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x3, vst1_u8_x3, u8, arch::uint8x8x3_t, gather3::<_, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x3, vst1_s8_x3, i8, arch::int8x8x3_t, gather3::<_, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x3, vst1_u16_x3, u16, arch::uint16x4x3_t, gather3::<_, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x3, vst1_s16_x3, i16, arch::int16x4x3_t, gather3::<_, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x3, vst1_u32_x3, u32, arch::uint32x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x3, vst1_s32_x3, i32, arch::int32x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x3, vst1_f32_x3, f32, arch::float32x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x3, vst1_u64_x3, u64, arch::uint64x1x3_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x3, vst1_s64_x3, i64, arch::int64x1x3_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x3, vst1_f64_x3, f64, arch::float64x1x3_t);
+
+    fn gather4<T: Copy, const N: usize, const M: usize>(v: [[T; M]; 4]) -> [T; N] {
+        <[T; N]>::try_from(v.as_flattened()).unwrap()
+    }
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u8_x4, vst1_u8_x4, u8, arch::uint8x8x4_t, gather4::<_, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i8_x4, vst1_s8_x4, i8, arch::int8x8x4_t, gather4::<_, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u16_x4, vst1_u16_x4, u16, arch::uint16x4x4_t, gather4::<_, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i16_x4, vst1_s16_x4, i16, arch::int16x4x4_t, gather4::<_, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u32_x4, vst1_u32_x4, u32, arch::uint32x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i32_x4, vst1_s32_x4, i32, arch::int32x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f32_x4, vst1_f32_x4, f32, arch::float32x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_u64_x4, vst1_u64_x4, u64, arch::uint64x1x4_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_i64_x4, vst1_s64_x4, i64, arch::int64x1x4_t);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1_f64_x4, vst1_f64_x4, f64, arch::float64x1x4_t);
 
     test_vst1_from_slice!(fn test_vst1q_u8, vst1q_u8, u8, arch::uint8x16_t);
     test_vst1_from_slice!(fn test_vst1q_i8, vst1q_s8, i8, arch::int8x16_t);
@@ -467,4 +772,37 @@ mod tests {
     test_vst1_from_slice!(fn test_vst1q_u64, vst1q_u64, u64, arch::uint64x2_t);
     test_vst1_from_slice!(fn test_vst1q_i64, vst1q_s64, i64, arch::int64x2_t);
     test_vst1_from_slice!(fn test_vst1q_f64, vst1q_f64, f64, arch::float64x2_t);
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x2, vst1q_u8_x2, u8, arch::uint8x16x2_t, gather2::<_, 32, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x2, vst1q_s8_x2, i8, arch::int8x16x2_t, gather2::<_, 32, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x2, vst1q_u16_x2, u16, arch::uint16x8x2_t, gather2::<_, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x2, vst1q_s16_x2, i16, arch::int16x8x2_t, gather2::<_, 16, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x2, vst1q_u32_x2, u32, arch::uint32x4x2_t, gather2::<_, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x2, vst1q_s32_x2, i32, arch::int32x4x2_t, gather2::<_, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x2, vst1q_f32_x2, f32, arch::float32x4x2_t, gather2::<_, 8, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x2, vst1q_u64_x2, u64, arch::uint64x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x2, vst1q_s64_x2, i64, arch::int64x2x2_t, gather2::<_, 4, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x2, vst1q_f64_x2, f64, arch::float64x2x2_t, gather2::<_, 4, 2>);
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x3, vst1q_u8_x3, u8, arch::uint8x16x3_t, gather3::<_, 48, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x3, vst1q_s8_x3, i8, arch::int8x16x3_t, gather3::<_, 48, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x3, vst1q_u16_x3, u16, arch::uint16x8x3_t, gather3::<_, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x3, vst1q_s16_x3, i16, arch::int16x8x3_t, gather3::<_, 24, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x3, vst1q_u32_x3, u32, arch::uint32x4x3_t, gather3::<_, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x3, vst1q_s32_x3, i32, arch::int32x4x3_t, gather3::<_, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x3, vst1q_f32_x3, f32, arch::float32x4x3_t, gather3::<_, 12, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x3, vst1q_u64_x3, u64, arch::uint64x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x3, vst1q_s64_x3, i64, arch::int64x2x3_t, gather3::<_, 6, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x3, vst1q_f64_x3, f64, arch::float64x2x3_t, gather3::<_, 6, 2>);
+
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u8_x4, vst1q_u8_x4, u8, arch::uint8x16x4_t, gather4::<_, 64, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i8_x4, vst1q_s8_x4, i8, arch::int8x16x4_t, gather4::<_, 64, 16>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u16_x4, vst1q_u16_x4, u16, arch::uint16x8x4_t, gather4::<_, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i16_x4, vst1q_s16_x4, i16, arch::int16x8x4_t, gather4::<_, 32, 8>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u32_x4, vst1q_u32_x4, u32, arch::uint32x4x4_t, gather4::<_, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i32_x4, vst1q_s32_x4, i32, arch::int32x4x4_t, gather4::<_, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f32_x4, vst1q_f32_x4, f32, arch::float32x4x4_t, gather4::<_, 16, 4>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_u64_x4, vst1q_u64_x4, u64, arch::uint64x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_i64_x4, vst1q_s64_x4, i64, arch::int64x2x4_t, gather4::<_, 8, 2>);
+    test_vst1_from_slice!(#[cfg_attr(miri, ignore)] fn test_vst1q_f64_x4, vst1q_f64_x4, f64, arch::float64x2x4_t, gather4::<_, 8, 2>);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@
 //! Currently, there is no plan to implement gather/scatter or masked load/store
 //! intrinsics for this platform.
 //!
+//! ### `aarch64`, `arm64ec`
+//! - `neon`
+//!
+//! Intrinsics that load / store individual lanes are not designed yet.
+//!
 //! ### Other platforms
 //!
 //! Not yet supported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@
 #[cfg(target_arch = "x86")]
 pub mod x86;
 
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+pub mod aarch64;
+
 #[cfg(target_arch = "x86_64")]
 mod x86;
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
This PR drafts added abstractions for neon SIMD on aarch64. This is mainly for verifying with you on the macro heavy implementation style. As a noted difference to x86 we do not have any 'unaligned' intrinsics per se, rather vector registers can be filled with variously sized element types which dictate the alignment down to 1-align. Of course the reinterpretation of these vectors is still just a high-level artifact¹ that does not appear in assembly but I did not want to deviate from the apparently established style.

This implies there will be a `Cell` variant each. The ergonomics of this remains to be evaluated. For instance we may instead want to opt for a type-generic equivalence trait in this crate. On that note, there is no intrinsic loading with alignment above 8 byte boundaries. However, such assertions exist in the _instruction encoding_ where you could go up to 256-bit / 32 byte boundaries. I don't expect LLVM to propagate the over-alignment from a generic input type and shared references guarantees but we might find out.


¹Registers are just denoted: `<Vd>.<Ts>[<index>]` for register Vd, at size Ts, accessing element index.