### PR TITLE
Move `x86` cell functions to their own module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Platform-intrinsics that take raw pointers have been wrapped in functions that r
 ### `x86`, `x86_64`
 - `sse`, `sse2`, `avx`
 
+Some functions have variants that are generic over `Cell` array types, which allow for mutation of shared references.
+
 Some example function signatures:
 ```rust
 #[target_feature(enable = "sse")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 //! ### `x86`, `x86_64`
 //! - `sse`, `sse2`, `avx`
 //!
+//! Some functions have variants that are generic over `Cell` array types,
+//! which allow for mutation of shared references.
+//!
 //! Currently, there is no plan to implement gather/scatter or masked load/store
 //! intrinsics for this platform.
 //!

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -18,6 +18,8 @@ pub use self::sse2::*;
 mod avx;
 pub use self::avx::*;
 
+pub mod cell;
+
 // Internal module for sealing SIMD traits.
 mod private {
     pub trait Sealed {}

--- a/src/x86/cell.rs
+++ b/src/x86/cell.rs
@@ -1,0 +1,40 @@
+//! Functions generic over [`Cell`][Cell] array types.
+//!
+//! These functions enable loading and storing of `&Cell[T; N]>` and
+//! `&[Cell<T>; N]`, shared mutable container types which permit mutability
+//! even in the presence of aliasing.
+//!
+//! This allows for operating on overlapping slices similar to how one could use
+//! the `std::arch` intrinsics with raw pointers.
+//!
+//! [Cell]: core::cell::Cell
+//!
+//! ```rust
+//! # unsafe { slide_right() }
+//! use core::cell::Cell;
+//!
+//! #[cfg(target_arch = "x86")]
+//! use safe_unaligned_simd::x86::cell;
+//! #[cfg(target_arch = "x86_64")]
+//! use safe_unaligned_simd::x86_64::cell;
+//!
+//! #[target_feature(enable = "sse2")]
+//! fn slide_right() {
+//!    let mut a = [0u16, 1, 2, 3, 4, 5, 6, 7, 8];
+//!    let val = Cell::from_mut(&mut a[..]).as_slice_of_cells();
+//!
+//!    let load: &[_; 8] = val[..8].try_into().unwrap();
+//!    let store: &[_; 8] = val[1..].try_into().unwrap();
+//!
+//!    let r = cell::_mm_loadu_si128(load);
+//!    cell::_mm_storeu_si128(store, r);
+//!
+//!    assert_eq!(a, [0, 0, 1, 2, 3, 4, 5, 6, 7]);
+//! }
+//! ```
+
+mod sse2;
+pub use sse2::*;
+
+mod avx;
+pub use avx::*;

--- a/src/x86/cell/avx.rs
+++ b/src/x86/cell/avx.rs
@@ -1,0 +1,114 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m256i};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{self as arch, __m256i};
+use core::ptr;
+
+#[cfg(target_arch = "x86")]
+use crate::x86::{Is128CellUnaligned, Is256CellUnaligned};
+#[cfg(target_arch = "x86_64")]
+use crate::x86_64::{Is128CellUnaligned, Is256CellUnaligned};
+
+/// Loads 256-bits of integer data from memory into result.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_loadu_si256)
+#[inline]
+#[target_feature(enable = "avx")]
+pub fn _mm256_loadu_si256<T: Is256CellUnaligned>(mem_addr: &T) -> __m256i {
+    unsafe { arch::_mm256_loadu_si256(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Loads two 128-bit values (composed of integer data) from memory, and combine
+/// them into a 256-bit value.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_loadu2_m128i)
+#[inline]
+#[target_feature(enable = "avx")]
+pub fn _mm256_loadu2_m128i<T: Is128CellUnaligned>(hiaddr: &T, loaddr: &T) -> __m256i {
+    unsafe { arch::_mm256_loadu2_m128i(ptr::from_ref(hiaddr).cast(), ptr::from_ref(loaddr).cast()) }
+}
+
+/// Stores 256-bits of integer data from `a` into memory.
+/// `mem_addr` does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_storeu_si256)
+#[inline]
+#[target_feature(enable = "avx")]
+pub fn _mm256_storeu_si256<T: Is256CellUnaligned>(mem_addr: &T, a: __m256i) {
+    unsafe { arch::_mm256_storeu_si256(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
+/// Stores the high and low 128-bit halves (each composed of integer data) from
+/// `a` into memory two different 128-bit locations.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_storeu2_m128i)
+#[inline]
+#[target_feature(enable = "avx")]
+pub fn _mm256_storeu2_m128i<T: Is128CellUnaligned>(hiaddr: &T, loaddr: &T, a: __m256i) {
+    unsafe {
+        arch::_mm256_storeu2_m128i(
+            ptr::from_ref(hiaddr).cast_mut().cast(),
+            ptr::from_ref(loaddr).cast_mut().cast(),
+            a,
+        )
+    }
+}
+
+#[cfg(feature = "_avx_test")]
+#[cfg(test)]
+mod tests {
+    // Fail-safe for tests being run on a CPU that doesn't support `avx`
+    static CPU_HAS_AVX: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| is_x86_feature_detected!("avx"));
+
+    #[test]
+    fn test_mm256_storeu2_m128i() {
+        assert!(*CPU_HAS_AVX);
+
+        unsafe { test() }
+
+        #[target_feature(enable = "avx")]
+        fn test() {
+            let mut st_hi: [i64; 3] = [30, 40, 0];
+            let mut st_lo: [i64; 3] = [10, 20, 0];
+
+            let hi = core::cell::Cell::from_mut(&mut st_hi[..]).as_slice_of_cells();
+            let lo = core::cell::Cell::from_mut(&mut st_lo[..]).as_slice_of_cells();
+
+            let lhi: &[_; 2] = hi[0..2].try_into().unwrap();
+            let llo: &[_; 2] = lo[0..2].try_into().unwrap();
+
+            let shi: &[_; 2] = hi[1..3].try_into().unwrap();
+            let slo: &[_; 2] = lo[1..3].try_into().unwrap();
+
+            let a = super::_mm256_loadu2_m128i(lhi, llo);
+            super::_mm256_storeu2_m128i(shi, slo, a);
+
+            assert_eq!(st_hi, [30, 30, 40]);
+            assert_eq!(st_lo, [10, 10, 20]);
+        }
+    }
+
+    #[test]
+    fn test_mm256_loadu_si256() {
+        assert!(*CPU_HAS_AVX);
+
+        unsafe { test() }
+
+        #[target_feature(enable = "avx")]
+        fn test() {
+            let mut x: [i16; 18] = core::array::from_fn(|i| i as i16);
+            let whole_cell = core::cell::Cell::from_mut(&mut x[..]);
+
+            let in_cell: &[_; 16] = whole_cell.as_slice_of_cells()[..16].try_into().unwrap();
+            let mm256 = super::_mm256_loadu_si256(in_cell);
+
+            let out_cell: &[_; 16] = whole_cell.as_slice_of_cells()[2..].try_into().unwrap();
+            super::_mm256_storeu_si256(out_cell, mm256);
+
+            let y: [i16; 16] = core::array::from_fn(|i| i as i16);
+            // We copied it over into this area of the underlying storage
+            assert_eq!(y, x[2..]);
+        }
+    }
+}

--- a/src/x86/cell/sse2.rs
+++ b/src/x86/cell/sse2.rs
@@ -1,0 +1,130 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m128i};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{self as arch, __m128i};
+use core::ptr;
+
+#[cfg(target_arch = "x86")]
+use crate::x86::Is128CellUnaligned;
+#[cfg(target_arch = "x86_64")]
+use crate::x86_64::Is128CellUnaligned;
+
+/// Loads a 64-bit integer from memory into first element of returned vector.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadl_epi64)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_loadl_epi64<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadl_epi64(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Loads 128-bits of integer data from memory into a new vector.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si128)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_loadu_si128<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_si128(ptr::from_ref(mem_addr).cast_mut().cast()) }
+}
+
+/// Stores the lower 64-bit integer `a` to a memory location.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storel_epi64)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_storel_epi64<T: Is128CellUnaligned>(mem_addr: &T, a: __m128i) {
+    unsafe { arch::_mm_storel_epi64(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
+/// Stores 128-bits of integer data from `a` into memory.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si128)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_storeu_si128<T: Is128CellUnaligned>(mem_addr: &T, a: __m128i) {
+    unsafe { arch::_mm_storeu_si128(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128i};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{self as arch, __m128i};
+
+    // SAFETY: The `x86_64` target baseline includes `sse` and `sse2`.
+
+    fn assert_eq_m128i(a: __m128i, b: __m128i) {
+        let a: [u8; 16] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 16] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    #[test]
+    fn test_mm_loadl_epi64() {
+        let mut a = [20, 25];
+        unsafe { test(&mut a) }
+
+        #[target_feature(enable = "sse2")]
+        fn test(a: &mut [i64; 2]) {
+            let val = core::cell::Cell::from_mut(a);
+            let r = super::_mm_loadl_epi64(val);
+            let target = arch::_mm_set_epi64x(0, 20);
+
+            assert_eq_m128i(r, target)
+        }
+    }
+
+    #[test]
+    fn test_mm_storel_epi64() {
+        unsafe { test() }
+
+        #[target_feature(enable = "sse2")]
+        fn test() {
+            let a = arch::_mm_set_epi64x(i64::MIN, i64::MAX);
+            let mut x = [0; 2];
+            let val = core::cell::Cell::from_mut(&mut x);
+            super::_mm_storel_epi64(val, a);
+
+            assert_eq!(x[0], i64::MAX);
+        }
+    }
+
+    #[test]
+    fn test_mm_storeu_si128_epi32() {
+        unsafe { test() }
+
+        #[target_feature(enable = "sse2")]
+        fn test() {
+            let mut a = [0u32, 1, 2, 3, 4];
+            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
+
+            let load: &[_; 4] = val[..4].try_into().unwrap();
+            let store: &[_; 4] = val[1..].try_into().unwrap();
+
+            let r = super::_mm_loadu_si128(load);
+            super::_mm_storeu_si128(store, r);
+
+            assert_eq!(a, [0, 0, 1, 2, 3]);
+        }
+    }
+
+    #[test]
+    fn test_mm_loadu_si128_i64() {
+        let mut a = [-1, -2, 0];
+        unsafe { test(&mut a) }
+
+        #[target_feature(enable = "sse2")]
+        fn test(a: &mut [i64; 3]) {
+            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
+
+            let load: &[_; 2] = val[..2].try_into().unwrap();
+            let store: &[_; 2] = val[1..].try_into().unwrap();
+
+            let r = super::_mm_loadu_si128(load);
+            super::_mm_storeu_si128(store, r);
+
+            assert_eq!(*a, [-1, -1, -2]);
+        }
+    }
+}

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -5,9 +5,9 @@ use core::arch::x86_64::{self as arch, __m128d, __m128i};
 use core::ptr;
 
 #[cfg(target_arch = "x86")]
-use crate::x86::{Is128BitsUnaligned, Is128CellUnaligned};
+use crate::x86::Is128BitsUnaligned;
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::{Is128BitsUnaligned, Is128CellUnaligned};
+use crate::x86_64::Is128BitsUnaligned;
 
 /// Loads a double-precision (64-bit) floating-point element from memory
 /// into both elements of returned vector.
@@ -59,15 +59,6 @@ pub fn _mm_loadl_epi64<T: Is128BitsUnaligned>(mem_addr: &T) -> __m128i {
     unsafe { arch::_mm_loadl_epi64(ptr::from_ref(mem_addr).cast()) }
 }
 
-/// Loads a 64-bit integer from memory into first element of returned vector.
-///
-/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadl_epi64)
-#[inline]
-#[target_feature(enable = "sse2")]
-pub fn _mm_loadl_epi64_cell<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
-    unsafe { arch::_mm_loadl_epi64(ptr::from_ref(mem_addr).cast()) }
-}
-
 /// Loads a double-precision value into the low-order bits of a 128-bit
 /// vector of `[2 x double]`. The high-order bits are copied from the
 /// high-order bits of the first operand.
@@ -96,15 +87,6 @@ pub fn _mm_loadu_pd(mem_addr: &[f64; 2]) -> __m128d {
 #[target_feature(enable = "sse2")]
 pub fn _mm_loadu_si128<T: Is128BitsUnaligned>(mem_addr: &T) -> __m128i {
     unsafe { arch::_mm_loadu_si128(ptr::from_ref(mem_addr).cast()) }
-}
-
-/// Loads 128-bits of integer data from memory into a new vector.
-///
-/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si128)
-#[inline]
-#[target_feature(enable = "sse2")]
-pub fn _mm_loadu_si128_cell<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
-    unsafe { arch::_mm_loadu_si128(ptr::from_ref(mem_addr).cast_mut().cast()) }
 }
 
 /// Loads unaligned 16-bits of integer data from memory into new vector.
@@ -163,15 +145,6 @@ pub fn _mm_storel_epi64<T: Is128BitsUnaligned>(mem_addr: &mut T, a: __m128i) {
     unsafe { arch::_mm_storel_epi64(ptr::from_mut(mem_addr).cast(), a) }
 }
 
-/// Stores the lower 64-bit integer `a` to a memory location.
-///
-/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storel_epi64)
-#[inline]
-#[target_feature(enable = "sse2")]
-pub fn _mm_storel_epi64_cell<T: Is128CellUnaligned>(mem_addr: &T, a: __m128i) {
-    unsafe { arch::_mm_storel_epi64(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
-}
-
 /// Stores the lower 64 bits of a 128-bit vector of `[2 x double]` to a
 /// memory location.
 ///
@@ -199,15 +172,6 @@ pub fn _mm_storeu_pd(mem_addr: &mut [f64; 2], a: __m128d) {
 #[target_feature(enable = "sse2")]
 pub fn _mm_storeu_si128<T: Is128BitsUnaligned>(mem_addr: &mut T, a: __m128i) {
     unsafe { arch::_mm_storeu_si128(ptr::from_mut(mem_addr).cast(), a) }
-}
-
-/// Stores 128-bits of integer data from `a` into memory.
-///
-/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si128)
-#[inline]
-#[target_feature(enable = "sse2")]
-pub fn _mm_storeu_si128_cell<T: Is128CellUnaligned>(mem_addr: &T, a: __m128i) {
-    unsafe { arch::_mm_storeu_si128(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
 }
 
 /// Store 16-bit integer from the first element of `a` into memory.
@@ -309,21 +273,6 @@ mod tests {
         #[target_feature(enable = "sse2")]
         fn test(a: &[i64; 2]) {
             let r = super::_mm_loadl_epi64(a);
-            let target = arch::_mm_set_epi64x(0, 20);
-
-            assert_eq_m128i(r, target)
-        }
-    }
-
-    #[test]
-    fn test_mm_loadl_epi64_cell() {
-        let mut a = [20, 25];
-        unsafe { test(&mut a) }
-
-        #[target_feature(enable = "sse2")]
-        fn test(a: &mut [i64; 2]) {
-            let val = core::cell::Cell::from_mut(a);
-            let r = super::_mm_loadl_epi64_cell(val);
             let target = arch::_mm_set_epi64x(0, 20);
 
             assert_eq_m128i(r, target)
@@ -440,40 +389,6 @@ mod tests {
             super::_mm_storel_epi64(&mut x, a);
 
             assert_eq!(x[0], i64::MAX);
-        }
-    }
-
-    #[test]
-    fn test_mm_storel_epi64_cell() {
-        unsafe { test() }
-
-        #[target_feature(enable = "sse2")]
-        fn test() {
-            let a = arch::_mm_set_epi64x(i64::MIN, i64::MAX);
-            let mut x = [0; 2];
-            let val = core::cell::Cell::from_mut(&mut x);
-            super::_mm_storel_epi64_cell(val, a);
-
-            assert_eq!(x[0], i64::MAX);
-        }
-    }
-
-    #[test]
-    fn test_mm_storeu_si128_epi32_cell() {
-        unsafe { test() }
-
-        #[target_feature(enable = "sse2")]
-        fn test() {
-            let mut a = [0u32, 1, 2, 3, 4];
-            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
-
-            let load: &[_; 4] = val[..4].try_into().unwrap();
-            let store: &[_; 4] = val[1..].try_into().unwrap();
-
-            let r = super::_mm_loadu_si128_cell(load);
-            super::_mm_storeu_si128_cell(store, r);
-
-            assert_eq!(a, [0, 0, 1, 2, 3]);
         }
     }
 
@@ -663,25 +578,6 @@ mod tests {
             let target = arch::_mm_set_epi64x(-2, -1);
 
             assert_eq_m128i(r, target);
-        }
-    }
-
-    #[test]
-    fn test_mm_loadu_si128_i64_cell() {
-        let mut a = [-1, -2, 0];
-        unsafe { test(&mut a) }
-
-        #[target_feature(enable = "sse2")]
-        fn test(a: &mut [i64; 3]) {
-            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
-
-            let load: &[_; 2] = val[..2].try_into().unwrap();
-            let store: &[_; 2] = val[1..].try_into().unwrap();
-
-            let r = super::_mm_loadu_si128_cell(load);
-            super::_mm_storeu_si128_cell(store, r);
-
-            assert_eq!(*a, [-1, -1, -2]);
         }
     }
 


### PR DESCRIPTION
Relocate the `sse2` and `avx` cell functions to the `cell` module
Remove the `_cell` suffix from these functions
Provide a code example for using `Cell` intrinsics

I wanted a better way to surface these functions to users and give an example of how to use them, even if it's not the most compelling illustration.