### PR TITLE
Small fixups to documentation and consistency

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -38,21 +38,9 @@ jobs:
       - name: Build docs
         run: cargo doc --no-deps --no-default-features
 
-        # AVX target_feature enabled doctest and internal feature test
+        # AVX intrinsics testing
       - name: Test library (avx feature)
         run: cargo test --no-default-features --lib --features _avx_test
-        ## Enable +avx for this test
-      - name: Enable +avx for RUSTFLAGS
-        env:
-          RUSTFLAGS: "-Dwarnings -Ctarget-feature=+avx"
-        run: echo "Enabling +avx for RUSTFLAGS - ${{ env.RUSTFLAGS }}"
-      - name: Doc tests (avx target feature)
-        run: cargo test --no-default-features --doc
-        ## Disable +avx
-      - name: Reset RUSTFLAGS to default
-        env:
-          RUSTFLAGS: "-Dwarnings"
-        run: echo "Resetting RUSTFLAGS - ${{ env.RUSTFLAGS }}"
 
         # Nightly feature tests
       - name: Test library (nightly feature)
@@ -61,7 +49,7 @@ jobs:
       - name: Doc tests (nightly feature)
         if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo test --no-default-features --doc --features nightly
-      - name: Build docs (nightly)
+      - name: Build docs (nightly feature)
         if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo doc --no-deps --no-default-features --features nightly
 
@@ -98,7 +86,7 @@ jobs:
       - name: Doc tests (nightly feature)
         if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo test --no-default-features --doc --features nightly
-      - name: Build docs (nightly)
+      - name: Build docs (nightly feature)
         if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo doc --no-deps --no-default-features --features nightly
 
@@ -121,7 +109,7 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
-    needs: [build-x86]
+    needs: [build-x86, build-aarch64]
     steps:
       - uses: actions/checkout@v4
       - name: Install Miri
@@ -134,4 +122,4 @@ jobs:
       - name: Test with Miri, Linux 32-bit x86 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu
       - name: Test with Miri, Linux 64-bit aarch64 target
-        run: cargo  miri test --features nightly --all-features --target aarch64-unknown-linux-gnu
+        run: RUSTFLAGS="-Dwarnings" cargo miri test --features nightly --all-features --target aarch64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Safe wrappers for unaligned SIMD load and store operations.
 
-The goal of this crate is to remove the need for "unnecessary `unsafe`" code when using memory vector intrinsics, with no alignment requirements.
+The goal of this crate is to remove the need for "unnecessary `unsafe`" code when using vector intrinsics to access memory, with no alignment requirements.
 
 Platform-intrinsics that take raw pointers have been wrapped in functions that receive Rust reference types as arguments.
 
-**MSRV**: 1.87
+**MSRV**: 1.88
 
 ## Implemented Intrinsics
 

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -2,24 +2,24 @@
 //!
 //! # Safety
 //!
-//! Vectored store and load instructions are encoded with an optional `<align>` field which none of
-//! the intrinsics here set themselves. (It could hint alignment 64/128/256). The field is then the
-//! default for which [the Neon programmer's guide][neon-documentation] (not the most stable link)
+//! Vectored load and store instructions are encoded with an optional `<align>` field which none of
+//! the intrinsics here set themselves (it can hint alignment 64/128/256). The field is then the
+//! default for which the [Neon programmer's guide][neon-documentation] (not the most stable link)
 //! notes the following:
 //!
-//! <i>When the alignment is not specified in the instruction, the alignment restriction is
+//! > <i>When the alignment is not specified in the instruction, the alignment restriction is
 //! controlled by the A bit \[of SCTLR\] \[… and\] if the A bit is 1, accesses must be element
 //! aligned.</i>
 //!
 //! [neon-documentation]: https://developer.arm.com/documentation/den0018/a/NEON-and-VFP-Instruction-Summary/NEON-load-and-store-instructions/VLDn--single-n-element-structure-to-all-lanes-?lang=en
 //!
-//! **Prior to version 20, llvm always inserted alignment assertions into the intrinsics. The crate
-//! is not sound prior to the bug fix (June 2025, rustc 1.88) with the LLVM backend. Other backends
-//! have not been verified.**
+//! **Prior to version 20, LLVM always inserted alignment assertions into the intrinsics. The crate
+//! is not sound  with the LLVM backend prior to the bug fix present in `rustc 1.88.0` (2025-06-23).
+//! Other backends have not been verified.**
 //!
-//! You *could* use all these intrinsics with completely unaligned memory if you set SCTLR, the
-//! system control register, which is not part of the guarantees. So we do not allow those. To load
-//! unaligned floating point data, use an appropriate u8xN type and reinterpret the vector.
+//! You *could* use all of these intrinsics with completely unaligned memory if you set the SCTLR,
+//! the system control register. Since we do not provide this guarantee, we do not allow that. To load
+//! unaligned floating point data, use an appropriate `u8xN` type and reinterpret the vector.
 //!
 //! See: <https://developer.arm.com/documentation/ddi0597/2025-06/SIMD-FP-Instructions/> on VLD1
 #![cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 //! ## Overview
 //!
 //! The goal of this crate is to remove the need for "unnecessary `unsafe`" code
-//! when using vector intrinsics with no alignment requirements.
+//! when using vector intrinsics to access memory, with no alignment
+//! requirements.
 //!
 //! Platform-intrinsics that take raw pointers have been wrapped in functions
 //! that receive Rust reference types as arguments.
@@ -30,11 +31,11 @@
 #![forbid(missing_docs, non_ascii_idents)]
 #![cfg_attr(not(test), no_std)]
 
-#[cfg(target_arch = "x86")]
-pub mod x86;
-
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
 pub mod aarch64;
+
+#[cfg(target_arch = "x86")]
+pub mod x86;
 
 #[cfg(target_arch = "x86_64")]
 mod x86;


### PR DESCRIPTION
Remove `+avx` target feature CI steps that never worked properly

Environment variables must be written to `$GITHUB_ENV` in order to persist between steps
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#passing-values-between-steps-and-jobs-in-a-workflow