### PR TITLE
Implement generic load/store for `Cell` types of 16/32/64 bits for `x86`

### DIFF
--- a/src/x86.rs
+++ b/src/x86.rs
@@ -25,13 +25,13 @@ mod private {
     pub trait Sealed {}
 }
 
-/// A trait that marks a type as valid for unaligned operations as an `i16`.
+/// A trait that marks a type as valid for unaligned operations as an [`i16`].
 pub trait Is16BitsUnaligned: private::Sealed {}
 
-/// A trait that marks a type as valid for unaligned operations as an `i32`.
+/// A trait that marks a type as valid for unaligned operations as an [`i32`].
 pub trait Is32BitsUnaligned: private::Sealed {}
 
-/// A trait that marks a type as valid for unaligned operations as an `i64`.
+/// A trait that marks a type as valid for unaligned operations as an [`i64`].
 pub trait Is64BitsUnaligned: private::Sealed {}
 
 /// A trait that marks a type as valid for unaligned operations as [`__m128i`],
@@ -42,12 +42,48 @@ pub trait Is128BitsUnaligned: private::Sealed {}
 /// an x86-specific 256-bit integer vector type.
 pub trait Is256BitsUnaligned: private::Sealed {}
 
-///////////////////////////////////////////
-// Start of `Cell` trait implementations //
-///////////////////////////////////////////
+////////////////////////////
+// Start of `Cell` traits //
+////////////////////////////
 
 impl<T, const N: usize> private::Sealed for [core::cell::Cell<T>; N] where [T; N]: private::Sealed {}
 impl<T, const N: usize> private::Sealed for core::cell::Cell<[T; N]> where [T; N]: private::Sealed {}
+
+/// Marks a cell-like type as valid for unaligned operations as [`i16`].
+pub trait Is16CellUnaligned: private::Sealed {}
+
+impl<T, const N: usize> Is16CellUnaligned for [core::cell::Cell<T>; N] where
+    [T; N]: Is16BitsUnaligned
+{
+}
+impl<T, const N: usize> Is16CellUnaligned for core::cell::Cell<[T; N]> where
+    [T; N]: Is16BitsUnaligned
+{
+}
+
+/// Marks a cell-like type as valid for unaligned operations as [`i32`].
+pub trait Is32CellUnaligned: private::Sealed {}
+
+impl<T, const N: usize> Is32CellUnaligned for [core::cell::Cell<T>; N] where
+    [T; N]: Is32BitsUnaligned
+{
+}
+impl<T, const N: usize> Is32CellUnaligned for core::cell::Cell<[T; N]> where
+    [T; N]: Is32BitsUnaligned
+{
+}
+
+/// Marks a cell-like type as valid for unaligned operations as [`i64`].
+pub trait Is64CellUnaligned: private::Sealed {}
+
+impl<T, const N: usize> Is64CellUnaligned for [core::cell::Cell<T>; N] where
+    [T; N]: Is64BitsUnaligned
+{
+}
+impl<T, const N: usize> Is64CellUnaligned for core::cell::Cell<[T; N]> where
+    [T; N]: Is64BitsUnaligned
+{
+}
 
 /// Marks a cell-like type as valid for unaligned operations as [`__m128i`], an
 /// x86-specific 128-bit integer vector type, on shared references.
@@ -74,6 +110,10 @@ impl<T, const N: usize> Is256CellUnaligned for core::cell::Cell<[T; N]> where
     [T; N]: Is256BitsUnaligned
 {
 }
+
+///////////////////////////
+// Macro implementations //
+///////////////////////////
 
 macro_rules! impl_N_bits_traits {
     (
@@ -103,6 +143,13 @@ impl_N_bits_traits! {
 }
 
 impl_N_bits_traits! {
+    impl Is16CellUnaligned [i16] for {
+        core::cell::Cell<u16>,
+        core::cell::Cell<i16>,
+    }
+}
+
+impl_N_bits_traits! {
     impl Is32BitsUnaligned [i32] for {
         [u8; 4],
         [i8; 4],
@@ -112,6 +159,13 @@ impl_N_bits_traits! {
         [i32; 1],
         u32,
         i32,
+    }
+}
+
+impl_N_bits_traits! {
+    impl Is32CellUnaligned [i32] for {
+        core::cell::Cell<u32>,
+        core::cell::Cell<i32>,
     }
 }
 
@@ -127,6 +181,13 @@ impl_N_bits_traits! {
         [i64; 1],
         u64,
         i64,
+    }
+}
+
+impl_N_bits_traits! {
+    impl Is64CellUnaligned [i64] for {
+        core::cell::Cell<u64>,
+        core::cell::Cell<i64>,
     }
 }
 

--- a/src/x86/cell/sse2.rs
+++ b/src/x86/cell/sse2.rs
@@ -5,9 +5,9 @@ use core::arch::x86_64::{self as arch, __m128i};
 use core::ptr;
 
 #[cfg(target_arch = "x86")]
-use crate::x86::Is128CellUnaligned;
+use crate::x86::{Is16CellUnaligned, Is32CellUnaligned, Is64CellUnaligned, Is128CellUnaligned};
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::Is128CellUnaligned;
+use crate::x86_64::{Is16CellUnaligned, Is32CellUnaligned, Is64CellUnaligned, Is128CellUnaligned};
 
 /// Loads a 64-bit integer from memory into first element of returned vector.
 ///
@@ -25,6 +25,33 @@ pub fn _mm_loadl_epi64<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
 #[target_feature(enable = "sse2")]
 pub fn _mm_loadu_si128<T: Is128CellUnaligned>(mem_addr: &T) -> __m128i {
     unsafe { arch::_mm_loadu_si128(ptr::from_ref(mem_addr).cast_mut().cast()) }
+}
+
+/// Loads unaligned 16-bits of integer data from memory into new vector.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si16)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_loadu_si16<T: Is16CellUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_si16(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Loads unaligned 32-bits of integer data from memory into new vector.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si32)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_loadu_si32<T: Is32CellUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_si32(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Loads unaligned 64-bits of integer data from memory into new vector.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si64)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_loadu_si64<T: Is64CellUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_si64(ptr::from_ref(mem_addr).cast()) }
 }
 
 /// Stores the lower 64-bit integer `a` to a memory location.
@@ -45,12 +72,41 @@ pub fn _mm_storeu_si128<T: Is128CellUnaligned>(mem_addr: &T, a: __m128i) {
     unsafe { arch::_mm_storeu_si128(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
 }
 
+/// Store 16-bit integer from the first element of `a` into memory.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si16)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_storeu_si16<T: Is16CellUnaligned>(mem_addr: &T, a: __m128i) {
+    unsafe { arch::_mm_storeu_si16(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
+/// Store 32-bit integer from the first element of `a` into memory.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si32)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_storeu_si32<T: Is32CellUnaligned>(mem_addr: &T, a: __m128i) {
+    unsafe { arch::_mm_storeu_si32(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
+/// Store 64-bit integer from the first element of `a` into memory.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si64)
+#[inline]
+#[target_feature(enable = "sse2")]
+pub fn _mm_storeu_si64<T: Is64CellUnaligned>(mem_addr: &T, a: __m128i) {
+    unsafe { arch::_mm_storeu_si64(ptr::from_ref(mem_addr).cast_mut().cast(), a) }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "x86")]
     use core::arch::x86::{self as arch, __m128i};
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128i};
+
+    use core::{array, cell::Cell};
 
     // SAFETY: The `x86_64` target baseline includes `sse` and `sse2`.
 
@@ -67,7 +123,7 @@ mod tests {
 
         #[target_feature(enable = "sse2")]
         fn test(a: &mut [i64; 2]) {
-            let val = core::cell::Cell::from_mut(a);
+            let val = Cell::from_mut(a);
             let r = super::_mm_loadl_epi64(val);
             let target = arch::_mm_set_epi64x(0, 20);
 
@@ -83,48 +139,161 @@ mod tests {
         fn test() {
             let a = arch::_mm_set_epi64x(i64::MIN, i64::MAX);
             let mut x = [0; 2];
-            let val = core::cell::Cell::from_mut(&mut x);
+            let val = Cell::from_mut(&mut x);
             super::_mm_storel_epi64(val, a);
 
             assert_eq!(x[0], i64::MAX);
         }
     }
 
-    #[test]
-    fn test_mm_storeu_si128_epi32() {
-        unsafe { test() }
+    macro_rules! test_loadu_storeu_siXYZ {
+        ($testname:ident, $loadu:ident, $storeu:ident, [$target:ty] for $($source:ty,)*) => {
+            #[test]
+            fn $testname() {
+                $({
+                    let mut a = array::from_fn(|i| i as $source);
+                    unsafe { test(&mut a) }
 
-        #[target_feature(enable = "sse2")]
-        fn test() {
-            let mut a = [0u32, 1, 2, 3, 4];
-            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
+                    const LOAD_INDEX: usize = 1;
+                    const STORE_INDEX: usize = 3;
+                    const ARRAY_SIZE: usize = size_of::<$target>() + STORE_INDEX;
 
-            let load: &[_; 4] = val[..4].try_into().unwrap();
-            let store: &[_; 4] = val[1..].try_into().unwrap();
+                    #[target_feature(enable = "sse2")]
+                    fn test(a: &mut [$source; ARRAY_SIZE]) {
+                        // Number of sources that fit within $target
+                        const N: usize = size_of::<$target>() / size_of::<$source>();
 
-            let r = super::_mm_loadu_si128(load);
-            super::_mm_storeu_si128(store, r);
+                        // The equivalent scalar operation of this SIMD load and store
+                        let mut result = a.clone();
+                        result.copy_within(LOAD_INDEX..LOAD_INDEX + N, STORE_INDEX);
 
-            assert_eq!(a, [0, 0, 1, 2, 3]);
-        }
+                        let val = Cell::from_mut(&mut a[..]).as_slice_of_cells();
+
+                        let load: &[_; N] = val[LOAD_INDEX..][..N].try_into().unwrap();
+                        let store: &[_; N] = val[STORE_INDEX..][..N].try_into().unwrap();
+
+                        let r = super::$loadu(load);
+                        super::$storeu(store, r);
+
+                        assert_eq!(*a, result);
+                    }
+                })*
+            }
+        };
     }
 
-    #[test]
-    fn test_mm_loadu_si128_i64() {
-        let mut a = [-1, -2, 0];
-        unsafe { test(&mut a) }
+    macro_rules! test_loadu_storeu_siXYZ_scalar {
+        ($testname:ident, $loadu:ident, $storeu:ident, [$target:ty] for $($source:ty,)*) => {
+            #[test]
+            fn $testname() {
+                $({
+                    unsafe { test_scalar() }
 
-        #[target_feature(enable = "sse2")]
-        fn test(a: &mut [i64; 3]) {
-            let val = core::cell::Cell::from_mut(&mut a[..]).as_slice_of_cells();
+                    #[target_feature(enable = "sse2")]
+                    fn test_scalar() {
+                        let mut a: $source = 1;
 
-            let load: &[_; 2] = val[..2].try_into().unwrap();
-            let store: &[_; 2] = val[1..].try_into().unwrap();
+                        const NUM: $source = (<$source>::MAX).wrapping_add(100);
 
-            let r = super::_mm_loadu_si128(load);
-            super::_mm_storeu_si128(store, r);
+                        let load = Cell::from(NUM);
+                        let store = Cell::from_mut(&mut a);
 
-            assert_eq!(*a, [-1, -1, -2]);
-        }
+                        let r = super::$loadu(&load);
+                        super::$storeu(store, r);
+
+                        assert_eq!(a, NUM);
+                    }
+                })*
+            }
+        };
     }
+
+    // loadu_si16 and storeu_si16 variants
+
+    test_loadu_storeu_siXYZ!(
+        test_mm_loadu_si16,
+        _mm_loadu_si16,
+        _mm_storeu_si16,
+        [i16] for
+        u8,
+        i8,
+        u16,
+        i16,
+    );
+
+    test_loadu_storeu_siXYZ_scalar!(
+        test_mm_loadu_si16_scalar,
+        _mm_loadu_si16,
+        _mm_storeu_si16,
+        [i16] for
+        u16,
+        i16,
+    );
+
+    // loadu_si32 and storeu_si32 variants
+
+    test_loadu_storeu_siXYZ!(
+        test_mm_loadu_si32,
+        _mm_loadu_si32,
+        _mm_storeu_si32,
+        [i32] for
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+    );
+
+    test_loadu_storeu_siXYZ_scalar!(
+        test_mm_loadu_si32_scalar,
+        _mm_loadu_si32,
+        _mm_storeu_si32,
+        [i32] for
+        u32,
+        i32,
+    );
+
+    // loadu_si64 and storeu_si64 variants
+
+    test_loadu_storeu_siXYZ!(
+        test_mm_loadu_si64,
+        _mm_loadu_si64,
+        _mm_storeu_si64,
+        [i64] for
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        u64,
+        i64,
+    );
+
+    test_loadu_storeu_siXYZ_scalar!(
+        test_mm_loadu_si64_scalar,
+        _mm_loadu_si64,
+        _mm_storeu_si64,
+        [i64] for
+        u64,
+        i64,
+    );
+
+    // loadu_si128 and storeu_si128 variants
+
+    test_loadu_storeu_siXYZ!(
+        test_mm_loadu_si128,
+        _mm_loadu_si128,
+        _mm_storeu_si128,
+        [__m128i] for
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        u64,
+        i64,
+    );
 }


### PR DESCRIPTION
Manually implement the traits for scalar 16, 32, and 64 bit types
Implement the cell si128 tests in terms of the new generic macros

Followup to #6