### PR TITLE
Add caching to CI jobs, compiletest job fixups

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -120,17 +120,17 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Cache LLVM source and build folders
+      - name: Cache LLVM build/bin/ directory
         id: cache-llvm
         uses: actions/cache@v4
         with:
           path: |
-            ${{ github.workspace }}/llvm-project-llvmorg-20.1.8/
-            ${{ github.workspace }}/llvmbuild/
+            ${{ github.workspace }}/llvmbuild/bin/
           key: ${{ runner.os }}-llvm-20
 
       - name: Download LLVM and build FileCheck
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        # FileCheck doesn't exist because the cache wasn't hit, rebuild it
+        if: ${{ hashFiles('llvmbuild/bin/FileCheck') == '' }}
         run: |
           # Prepare build environment
           sudo apt -y update

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTDOCFLAGS: "-Dwarnings"
 jobs:
   build-x86:
-    name: Build and test crate/docs
+    name: Build and test crate
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -27,6 +27,11 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: rust-docs
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
         # Default build, no features
       - name: Build library
@@ -69,6 +74,11 @@ jobs:
           components: rust-docs
           targets: aarch64-apple-darwin
 
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
         # Default build, no features
       - name: Build library
         run: cargo build -v --lib --no-default-features --target aarch64-apple-darwin
@@ -99,12 +109,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: clippy
         run: cargo clippy
         continue-on-error: true
       - name: rustfmt
         run: cargo fmt -- --check
-        continue-on-error: true
+        continue-on-error: false
 
   codegen-x86:
     name: x86_64 assembly codegen tests
@@ -119,6 +135,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Cache LLVM build/bin/ directory
         id: cache-llvm
@@ -156,14 +177,26 @@ jobs:
     needs: [build-x86, build-aarch64]
     steps:
       - uses: actions/checkout@v4
-      - name: Install Miri
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri, rust-src
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Set up Miri
         run: |
-          rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
+
       - name: Test with Miri, Linux 64-bit x86_64 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target x86_64-unknown-linux-gnu
+
       - name: Test with Miri, Linux 32-bit x86 target
         run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu
+
       - name: Test with Miri, Linux 64-bit aarch64 target
         run: RUSTFLAGS="-Dwarnings" cargo miri test --features nightly --all-features --target aarch64-unknown-linux-gnu

--- a/tests/assembly/x86/sse.rs
+++ b/tests/assembly/x86/sse.rs
@@ -1,41 +1,42 @@
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -C llvm-args=-x86-asm-syntax=intel
-//@ compile-flags: -Copt-level=3 --target=x86_64-unknown-linux-gnu
+//@ compile-flags: -Copt-level=3
+//@ only: x86_64
 
 extern crate safe_unaligned_simd;
 
 use safe_unaligned_simd::x86_64 as simd;
 use std::arch::x86_64::__m128;
 
-// CHECK-LABEL: _mm_load1_ps:
+// CHECK-LABEL: _mm_load1_ps
 // CHECK: movss
 #[no_mangle]
 pub fn _mm_load1_ps(mem_addr: &f32) -> __m128 {
     unsafe { simd::_mm_load1_ps(mem_addr) }
 }
 
-// CHECK-LABEL: _mm_load_ss:
+// CHECK-LABEL: _mm_load_ss
 // CHECK: movss
 #[no_mangle]
 pub fn _mm_load_ss(mem_addr: &f32) -> __m128 {
     unsafe { simd::_mm_load_ss(mem_addr) }
 }
 
-// CHECK-LABEL: _mm_loadu_ps:
+// CHECK-LABEL: _mm_loadu_ps
 // CHECK: movups
 #[no_mangle]
 pub fn _mm_loadu_ps(mem_addr: &[f32; 4]) -> __m128 {
     unsafe { simd::_mm_loadu_ps(mem_addr) }
 }
 
-// CHECK-LABEL: _mm_store_ss:
+// CHECK-LABEL: _mm_store_ss
 // CHECK: movss
 #[no_mangle]
 pub fn _mm_store_ss(mem_addr: &mut f32, a: __m128) {
     unsafe { simd::_mm_store_ss(mem_addr, a) }
 }
 
-// CHECK-LABEL: _mm_storeu_ps:
+// CHECK-LABEL: _mm_storeu_ps
 // CHECK: movups
 #[no_mangle]
 #[target_feature(enable = "sse")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,9 @@
+// Compiletest documentation:
+//
+// https://rustc-dev-guide.rust-lang.org/tests/compiletest.html
+// https://rustc-dev-guide.rust-lang.org/tests/directives.html#assembly
+// https://rustc-dev-guide.rust-lang.org/tests/ui.html#controlling-passfail-expectations
+
 #[allow(dead_code)]
 #[cfg_attr(miri, ignore)]
 fn run_mode(mode: &'static str, custom_dir: Option<&'static str>) {
@@ -13,13 +19,11 @@ fn run_mode(mode: &'static str, custom_dir: Option<&'static str>) {
     config.clean_rlib();
     config.strict_headers = true;
     config.llvm_filecheck = Some(
+        // Set your local path to `FileCheck` as this environment variable
+        // unless it's already present in $PATH from installing LLVM with
+        // `-DLLVM_INSTALL_UTILS=ON` in cmake.
         std::env::var("FILECHECK")
-            /* Comment out this line if using the following solutions */
-            .unwrap_or("llvmbuild/bin/FileCheck".to_string())
-            /* Uncomment out this line if using locally built LLVM */
-            // .unwrap_or("FileCheck".to_string())
-            /* Uncomment out this line if using `pip install filecheck`*/
-            // .unwrap_or("filecheck".to_string())
+            .unwrap_or("FileCheck".to_string())
             .into(),
     );
 


### PR DESCRIPTION
Reconfigure compiletest caching to hopefully be more robust:
- Reduce the occupied cache space by only saving the /bin/ folder where FileCheck resides, and rebuild when FileCheck is missing.

Add compiletest documentation and fixup comments in `/tests/tests.rs` 
Add caching to other CI jobs
Allow rustfmt to fail
Use rust-toolchain to install nightly with Miri and rust-src components

Followup to #10 

---

Windows is the bottleneck for Miri running.
The `build-x86` core job should be split into a reusable workflow so we can have Miri require only the aarch64 and ubuntu-x86 builds completing.