### PR TITLE
Prepare for `0.2` release, update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,49 @@
 # `safe_unaligned_simd` changelog
 
+## Version 0.2.0 - 2025-07
+
+Version bump for changing the signature of some `sse2` functions.
+
+### Major changes
+
+- Added `neon` support for load and store on `aarch64`/`arm64ec` architectures
+- Adjusted `sse2` signatures of `_mm_loadu/storeu_si[16|32|64]` to use traits generic over 16, 32, and 64-bit width types
+- Added `Is[16|32|64|128|256]CellUnaligned` traits for `Cell` types in `x86`
+- MSRV increased to `1.88`
+
+#### aarch64 / arm64ec
+
+See the `aarch64` module for all implemented intrinsics.
+Mainly `VLD1` and `VST1` intrinsics were added.
+
+#### x86 / x86_64
+
+All of the remaining `std::arch` `x86`/`x86_64` intrinsics that take `u8` pointers are now wrapped by functions that use marker traits for the argument size.
+
+For example, a function which takes an input argument bounded by `<T: Is16BitsUnaligned>` can be called with `[u8; 2]`, `[i8; 2]`, `[u16; 1]`, `[i16; 1]`, `u16`, or `i16`.
+This affects the `_mm_loadu/storeu_si[16|32|64]` functions and matches the behavior of the `_si[128|256]` functions.
+
+Additionally, `Is__BitsUnaligned` now has a corresponding `Is__CellUnaligned` trait which enables using intrinsics with `&Cell<[T; N]>` and `&[Cell<T>; N]` types.
+These traits allow for operating on overlapping slices similar to how one can use `std::arch` intrinsics with raw pointers.
+The functions are located within an architecture's `cell` module.
+
+### Notable PRs
+
+[`#15`][15] - Implement generic load/store for Cell types of 16/32/64 bits for x86  
+[`#8`][8] - Abstractions around `aarch64` neon loads and stores  
+[`#6`][6] - Add traits for 16, 32, and 64 bit unaligned operations in x86  
+[`#4`][4] - Add cell variants for generic load/store (x86)
+
 ## Version 0.1.1 - 2025-07
 
-[#3][3] - Added `x86` support
+[`#3`][3] - Added `x86` support
 
 ## Version 0.1.0 - 2025-06
+
 Initial release
 
+[15]: https://github.com/okaneco/safe_unaligned_simd/pull/15
+[8]: https://github.com/okaneco/safe_unaligned_simd/pull/8
+[6]: https://github.com/okaneco/safe_unaligned_simd/pull/6
+[4]: https://github.com/okaneco/safe_unaligned_simd/pull/4
 [3]: https://github.com/okaneco/safe_unaligned_simd/pull/3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `safe_unaligned_simd`
 
-[![Build Status](https://github.com/okaneco/safe_unaligned_simd/workflows/Rust%20CI/badge.svg)](https://github.com/okaneco/safe_unaligned_simd)
+[![Build Status](https://github.com/okaneco/safe_unaligned_simd/actions/workflows/rust-ci.yml/badge.svg?branch=master)](https://github.com/okaneco/safe_unaligned_simd)
 [![Crates.io](https://img.shields.io/crates/v/safe_unaligned_simd.svg)](https://crates.io/crates/safe_unaligned_simd)
 [![Docs.rs](https://docs.rs/safe_unaligned_simd/badge.svg)](https://docs.rs/safe_unaligned_simd)
 
@@ -12,12 +12,13 @@ Platform-intrinsics that take raw pointers have been wrapped in functions that r
 
 **MSRV**: 1.88
 
-## Implemented Intrinsics
+## Supported target architectures
 
-### `x86`, `x86_64`
+### `x86` / `x86_64`
 - `sse`, `sse2`, `avx`
 
 Some functions have variants that are generic over `Cell` array types, which allow for mutation of shared references.
+See the [`cell`](./src/x86/cell.rs) module for an example.
 
 Some example function signatures:
 ```rust
@@ -41,10 +42,6 @@ fn vld2_dup_s8(from: &[i8; 2]) -> int8x8x2_t;
 #[target_feature(enable = "neon")]
 fn vst1q_f64(into: &mut [f64; 2], val: float64x2_t);
 ```
-
-### Other platforms
-
-Not yet supported.
 
 ## License
 This crate is licensed under either

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -14,7 +14,7 @@
 //! [neon-documentation]: https://developer.arm.com/documentation/den0018/a/NEON-and-VFP-Instruction-Summary/NEON-load-and-store-instructions/VLDn--single-n-element-structure-to-all-lanes-?lang=en
 //!
 //! **Prior to version 20, LLVM always inserted alignment assertions into the intrinsics. The crate
-//! is not sound  with the LLVM backend prior to the bug fix present in `rustc 1.88.0` (2025-06-23).
+//! is not sound with the LLVM backend prior to the bug fix present in `rustc 1.88.0` (2025-06-23).
 //! Other backends have not been verified.**
 //!
 //! You *could* use all of these intrinsics with completely unaligned memory if you set the SCTLR,
@@ -23,7 +23,6 @@
 //!
 //! See: <https://developer.arm.com/documentation/ddi0597/2025-06/SIMD-FP-Instructions/> on VLD1
 #![cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
-
 // Use all variants of registers.
 use core::arch::aarch64::{self as arch, *};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 //! Platform-intrinsics that take raw pointers have been wrapped in functions
 //! that receive Rust reference types as arguments.
 //!
-//! ## Implemented Intrinsics
+//! ## Supported target architectures
 //!
-//! ### `x86`, `x86_64`
+//! ### `x86` / `x86_64`
 //! - `sse`, `sse2`, `avx`
 //!
 //! Some functions have variants that are generic over `Cell` array types,
@@ -24,10 +24,6 @@
 //! - `neon`
 //!
 //! Intrinsics that load / store individual lanes are not designed yet.
-//!
-//! ### Other platforms
-//!
-//! Not yet supported.
 #![forbid(missing_docs, non_ascii_idents)]
 #![cfg_attr(not(test), no_std)]
 

--- a/src/x86/cell.rs
+++ b/src/x86/cell.rs
@@ -1,11 +1,11 @@
 //! Functions generic over [`Cell`][Cell] array types.
 //!
-//! These functions enable loading and storing of `&Cell[T; N]>` and
+//! These functions enable loading and storing of `&Cell<[T; N]>` and
 //! `&[Cell<T>; N]`, shared mutable container types which permit mutability
 //! even in the presence of aliasing.
 //!
-//! This allows for operating on overlapping slices similar to how one could use
-//! the `std::arch` intrinsics with raw pointers.
+//! This allows for operating on overlapping slices similar to how one can use
+//! `std::arch` intrinsics with raw pointers.
 //!
 //! [Cell]: core::cell::Cell
 //!


### PR DESCRIPTION
Update readme and changelog
Fixups in `cell.rs` and `aarch64.rs` docs

Readme.md:
Fix action badge to only point at master branch status
Remove unsupported arch section (update lib.rs to match)
Add cell module link

Rendered
https://github.com/okaneco/safe_unaligned_simd/blob/0.2-release-prep/README.md
https://github.com/okaneco/safe_unaligned_simd/blob/0.2-release-prep/CHANGELOG.md
