### PR TITLE
Fixup so `docs.rs` displays `x86_64` target as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `safe_unaligned_simd` changelog
 
+## Version 0.2.1 - 2025-07
+
+No functional change.  
+Patch release so docs.rs build defaults to `x86_64-unknown-linux-gnu` target.
+
 ## Version 0.2.0 - 2025-07
 
 Version bump for changing the signature of some `sse2` functions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_unaligned_simd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -34,4 +34,5 @@ _assembly_x86 = []
 [package.metadata.docs.rs]
 no-default-features = true
 features = [""]
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "i686-unknown-linux-gnu"]


### PR DESCRIPTION
Set the default-target to `x86_64-unknown-linux-gnu` in Cargo.toml and remove it from `targets`
This bumps the version to `0.2.1`.

I assumed x86_64 would stay as the default even when listed in `[package.metadata.docs.rs.targets]` but that's not the case.
The docs for the crate's `/latest/` point to the `aarch64-apple-darwin` target.