### PR TITLE
Allow codegen tests to fail temporarily

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -139,6 +139,7 @@ jobs:
   codegen-x86:
     name: x86_64 assembly codegen tests
     runs-on: ${{ matrix.os }}-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -184,6 +185,8 @@ jobs:
 
       - name: Run assembly tests
         run: cargo test --features _assembly_x86
+        # FIXME: workaround until the codegen tests are sorted
+        continue-on-error: true
 
   miri:
     name: Miri


### PR DESCRIPTION
The assembly codegen tests are still a proof of concept and haven't been specifically written. The update to LLVM 21 in nightly probably broke the tests.
Longer term, I think a flag needs to be passed not to combine functions or to have each function get its own individual test (or some other disassembly?).

However, this step was primarily implemented for testing non-temporal streaming intrinsics to ensure an sfence is present after using those intrinsics.