### PR TITLE
Implement AVX-512F intrinsic support, implement `loadu` instrinsics [1/3]

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -61,15 +61,37 @@ jobs:
       - name: Test library (avx feature)
         run: cargo test --no-default-features --lib --features _avx_test
 
+        # Check if AVX512F/VL target features are supported (VL requires F)
+      - name: Check supported native target features (AVX512F feature)
+        if: ${{ (matrix.os == 'ubuntu') }}
+        id: avx512f_check
+        run: |
+          if rustc --print=cfg -Ctarget-cpu=native | grep -l 'avx512vl'; then
+            echo "PRESENT=yes" >> $GITHUB_OUTPUT
+          else
+            echo "PRESENT=no" >> $GITHUB_OUTPUT
+          fi
+
+        # AVX512F feature tests, AVX512 was stabilized in 1.89s
+      - name: Test library (AVX512F feature)
+        if: ${{ (matrix.toolchain != '1.88') && (matrix.os == 'ubuntu') && (steps.avx512f_check.PRESENT == 'yes') }}
+        run: cargo test --no-default-features --lib --features avx512
+      - name: Doc tests (AVX512F feature)
+        if: ${{ (matrix.toolchain != '1.88') && (matrix.os == 'ubuntu') && (steps.avx512f_check.PRESENT == 'yes') }}
+        run: cargo test --no-default-features --doc --features avx512
+      - name: Build docs (AVX512F feature)
+        if: ${{ (matrix.toolchain != '1.88') && (matrix.os == 'ubuntu') && (steps.avx512f_check.PRESENT == 'yes') }}
+        run: cargo doc --no-deps --no-default-features --features avx512
+
         # Nightly feature tests
       - name: Test library (nightly feature)
-        if: ${{ matrix.toolchain == 'nightly' }}
+        if: ${{ (matrix.toolchain == 'nightly') }}
         run: cargo test --no-default-features --lib --features nightly
       - name: Doc tests (nightly feature)
-        if: ${{ matrix.toolchain == 'nightly' }}
+        if: ${{ (matrix.toolchain == 'nightly') }}
         run: cargo test --no-default-features --doc --features nightly
       - name: Build docs (nightly feature)
-        if: ${{ matrix.toolchain == 'nightly' }}
+        if: ${{ (matrix.toolchain == 'nightly') }}
         run: cargo doc --no-deps --no-default-features --features nightly
 
   build-aarch64:
@@ -256,10 +278,10 @@ jobs:
           cargo miri setup
 
       - name: Test with Miri, Linux 64-bit x86_64 target
-        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target x86_64-unknown-linux-gnu
+        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx,+avx512f,+avx512vl" cargo miri test --features _avx_test,avx512 --target x86_64-unknown-linux-gnu
 
       - name: Test with Miri, Linux 32-bit x86 target
-        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx" cargo miri test --features _avx_test,nightly --target i686-unknown-linux-gnu
+        run: RUSTFLAGS="-Dwarnings -Ctarget-feature=+avx,+avx512f,+avx512vl" cargo miri test --features _avx_test,avx512 --target i686-unknown-linux-gnu
 
       - name: Test with Miri, Linux 64-bit aarch64 target
         run: RUSTFLAGS="-Dwarnings" cargo miri test --features nightly --all-features --target aarch64-unknown-linux-gnu

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -66,6 +66,7 @@ jobs:
         if: ${{ (matrix.os == 'ubuntu') }}
         id: avx512f_check
         run: |
+          rustc --print=cfg -Ctarget-cpu=native
           if rustc --print=cfg -Ctarget-cpu=native | grep -l 'avx512vl'; then
             echo "PRESENT=yes" >> $GITHUB_OUTPUT
           else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ version = "0.11.0"
 
 [features]
 default = []
+# Enables the AVX512F, "Foundation", instruction set
+avx512f = []
 # Gain access to unstable features which require the nightly compiler
 nightly = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ version = "0.11.0"
 
 [features]
 default = []
-# Enables the AVX512F, "Foundation", instruction set
-avx512f = []
+# Enables AVX-512 intrinsics for x86
+avx512 = []
 # Gain access to unstable features which require the nightly compiler
 nightly = []
 
@@ -39,6 +39,6 @@ _assembly_x86 = []
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = [""]
+features = ["avx512"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "i686-unknown-linux-gnu", "wasm32-wasip1"]

--- a/src/common_traits.rs
+++ b/src/common_traits.rs
@@ -40,6 +40,12 @@ pub trait Is128BitsUnaligned: private::Sealed {}
 /// [x86]: https://doc.rust-lang.org/stable/core/arch/x86/struct.__m256i.html
 pub trait Is256BitsUnaligned: private::Sealed {}
 
+/// A trait that marks a type as valid for unaligned operations as a 512-bit
+/// integer vector type such as [`__m512i`][x86].
+///
+/// [x86]: https://doc.rust-lang.org/stable/core/arch/x86/struct.__m512i.html
+pub trait Is512BitsUnaligned: private::Sealed {}
+
 ////////////////////////////
 // Start of `Cell` traits //
 ////////////////////////////
@@ -270,10 +276,43 @@ impl_N_bits_traits! {
     }
 }
 
+impl_N_bits_traits! {
+    impl Is512BitsUnaligned [[i128; 4]] for {
+        [u8; 64],
+        [i8; 64],
+        [u16; 32],
+        [i16; 32],
+        [u32; 16],
+        [i32; 16],
+        [f32; 16],
+        [u64; 8],
+        [i64; 8],
+        [f64; 8],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m128; 4],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m128d; 4],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m128i; 4],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m128; 4],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m128d; 4],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m128i; 4],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m256; 2],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m256d; 2],
+        #[cfg(target_arch = "x86")] [core::arch::x86::__m256i; 2],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m256; 2],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m256d; 2],
+        #[cfg(target_arch = "x86_64")] [core::arch::x86_64::__m256i; 2],
+        #[cfg(target_arch = "x86")] core::arch::x86::__m512,
+        #[cfg(target_arch = "x86")] core::arch::x86::__m512d,
+        #[cfg(target_arch = "x86")] core::arch::x86::__m512i,
+        #[cfg(target_arch = "x86_64")] core::arch::x86_64::__m512,
+        #[cfg(target_arch = "x86_64")] core::arch::x86_64::__m512d,
+        #[cfg(target_arch = "x86_64")] core::arch::x86_64::__m512i,
+    }
+}
+
 #[cfg(target_arch = "x86")]
-use core::arch::x86::{__m128i, __m256i};
+use core::arch::x86::{__m128i, __m256i, __m512i};
 #[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::{__m128i, __m256i};
+use core::arch::x86_64::{__m128i, __m256i, __m512i};
 
 // Sanity check:
 // We define the 128/256-bit unaligned trait types in terms of `i128`.
@@ -281,3 +320,5 @@ use core::arch::x86_64::{__m128i, __m256i};
 const _: () = assert!(size_of::<i128>() == size_of::<__m128i>());
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const _: () = assert!(size_of::<[i128; 2]>() == size_of::<__m256i>());
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const _: () = assert!(size_of::<[i128; 4]>() == size_of::<__m512i>());

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -13,9 +13,9 @@ pub use self::sse2::*;
 mod avx;
 pub use self::avx::*;
 
-#[cfg(feature = "avx512f")]
+#[cfg(feature = "avx512")]
 mod avx512f;
-#[cfg(feature = "avx512f")]
+#[cfg(feature = "avx512")]
 pub use self::avx512f::*;
 
 pub mod cell;

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -13,10 +13,15 @@ pub use self::sse2::*;
 mod avx;
 pub use self::avx::*;
 
+#[cfg(feature = "avx512f")]
+mod avx512f;
+#[cfg(feature = "avx512f")]
+pub use self::avx512f::*;
+
 pub mod cell;
 
 pub use crate::common_traits::{
     Is16BitsUnaligned, Is16CellUnaligned, Is32BitsUnaligned, Is32CellUnaligned, Is64BitsUnaligned,
     Is64CellUnaligned, Is128BitsUnaligned, Is128CellUnaligned, Is256BitsUnaligned,
-    Is256CellUnaligned,
+    Is256CellUnaligned, Is512BitsUnaligned,
 };

--- a/src/x86/avx512f.rs
+++ b/src/x86/avx512f.rs
@@ -1,0 +1,86 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{self as arch, __m128i, __mmask8};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{self as arch, __m128i, __mmask8};
+use core::ptr;
+
+#[cfg(target_arch = "x86")]
+use crate::x86::Is128BitsUnaligned;
+#[cfg(target_arch = "x86_64")]
+use crate::x86_64::Is128BitsUnaligned;
+
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_expandloadu_epi32<T: Is128BitsUnaligned>(
+    src: __m128i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m128i {
+    unsafe { arch::_mm_mask_expandloadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_expandloadu_epi32<T: Is128BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m128i {
+    _mm_mask_expandloadu_epi32(arch::_mm_setzero_si128(), k, mem_addr)
+}
+
+#[cfg(feature = "avx512f")]
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128i};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{self as arch, __m128i};
+
+    use core::hint::black_box;
+
+    // Fail-safe for tests being run on a CPU that doesn't support the instructions
+    static CPU_HAS_AVX512VL: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| is_x86_feature_detected!("avx512vl"));
+
+    fn assert_eq_m128i(a: __m128i, b: __m128i) {
+        let a: [u8; 16] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 16] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4];
+            let m = 0b11111000;
+            let r = super::_mm_mask_expandloadu_epi32(src, m, black_box(a));
+            let e = arch::_mm_set_epi32(1, 42, 42, 42);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4];
+            let m = 0b11111000;
+            let r = super::_mm_maskz_expandloadu_epi32(m, black_box(a));
+            let e = arch::_mm_set_epi32(1, 0, 0, 0);
+            assert_eq_m128i(r, e);
+        }
+    }
+}

--- a/src/x86/avx512f.rs
+++ b/src/x86/avx512f.rs
@@ -258,7 +258,379 @@ pub fn _mm512_maskz_expandloadu_ps(k: __mmask16, mem_addr: &[f32; 16]) -> __m512
     _mm512_mask_expandloadu_ps(arch::_mm512_setzero_ps(), k, mem_addr)
 }
 
-#[cfg(feature = "avx512f")]
+/// Load 128-bits (composed of 4 packed 32-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_loadu_epi32<T: Is128BitsUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_epi32(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_loadu_epi32<T: Is128BitsUnaligned>(
+    src: __m128i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m128i {
+    unsafe { arch::_mm_mask_loadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_loadu_epi32<T: Is128BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m128i {
+    _mm_mask_loadu_epi32(arch::_mm_setzero_si128(), k, mem_addr)
+}
+
+/// Load 256-bits (composed of 8 packed 32-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_loadu_epi32<T: Is256BitsUnaligned>(mem_addr: &T) -> __m256i {
+    unsafe { arch::_mm256_loadu_epi32(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_loadu_epi32<T: Is256BitsUnaligned>(
+    src: __m256i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m256i {
+    unsafe { arch::_mm256_mask_loadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_loadu_epi32<T: Is256BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m256i {
+    _mm256_mask_loadu_epi32(arch::_mm256_setzero_si256(), k, mem_addr)
+}
+
+/// Load 512-bits (composed of 16 packed 32-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_loadu_epi32<T: Is512BitsUnaligned>(mem_addr: &T) -> __m512i {
+    unsafe { arch::_mm512_loadu_epi32(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_loadu_epi32<T: Is512BitsUnaligned>(
+    src: __m512i,
+    k: __mmask16,
+    mem_addr: &T,
+) -> __m512i {
+    unsafe { arch::_mm512_mask_loadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 32-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_loadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_loadu_epi32<T: Is512BitsUnaligned>(k: __mmask16, mem_addr: &T) -> __m512i {
+    _mm512_mask_loadu_epi32(arch::_mm512_setzero_si512(), k, mem_addr)
+}
+
+/// Load 128-bits (composed of 2 packed 64-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_loadu_epi64<T: Is128BitsUnaligned>(mem_addr: &T) -> __m128i {
+    unsafe { arch::_mm_loadu_epi64(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_loadu_epi64<T: Is128BitsUnaligned>(
+    src: __m128i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m128i {
+    unsafe { arch::_mm_mask_loadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_loadu_epi64<T: Is128BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m128i {
+    _mm_mask_loadu_epi64(arch::_mm_setzero_si128(), k, mem_addr)
+}
+
+/// Load 256-bits (composed of 4 packed 64-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_loadu_epi64<T: Is256BitsUnaligned>(mem_addr: &T) -> __m256i {
+    unsafe { arch::_mm256_loadu_epi64(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_loadu_epi64<T: Is256BitsUnaligned>(
+    src: __m256i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m256i {
+    unsafe { arch::_mm256_mask_loadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_loadu_epi64<T: Is256BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m256i {
+    _mm256_mask_loadu_epi64(arch::_mm256_setzero_si256(), k, mem_addr)
+}
+
+/// Load 512-bits (composed of 8 packed 64-bit integers) from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_loadu_epi64<T: Is512BitsUnaligned>(mem_addr: &T) -> __m512i {
+    unsafe { arch::_mm512_loadu_epi64(ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_loadu_epi64<T: Is512BitsUnaligned>(
+    src: __m512i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m512i {
+    unsafe { arch::_mm512_mask_loadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load packed 64-bit integers from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_loadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_loadu_epi64<T: Is512BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m512i {
+    _mm512_mask_loadu_epi64(arch::_mm512_setzero_si512(), k, mem_addr)
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_loadu_pd(src: __m128d, k: __mmask8, mem_addr: &[f64; 2]) -> __m128d {
+    unsafe { arch::_mm_mask_loadu_pd(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_loadu_pd(k: __mmask8, mem_addr: &[f64; 2]) -> __m128d {
+    _mm_mask_loadu_pd(arch::_mm_setzero_pd(), k, mem_addr)
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_loadu_pd(src: __m256d, k: __mmask8, mem_addr: &[f64; 4]) -> __m256d {
+    unsafe { arch::_mm256_mask_loadu_pd(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_loadu_pd(k: __mmask8, mem_addr: &[f64; 4]) -> __m256d {
+    _mm256_mask_loadu_pd(arch::_mm256_setzero_pd(), k, mem_addr)
+}
+
+/// Loads 512-bits (composed of 8 packed double-precision (64-bit)
+/// floating-point elements) from memory into result.
+/// `mem_addr` does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_loadu_pd(mem_addr: &[f64; 8]) -> __m512d {
+    unsafe { arch::_mm512_loadu_pd(mem_addr.as_ptr()) }
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_loadu_pd(src: __m512d, k: __mmask8, mem_addr: &[f64; 8]) -> __m512d {
+    unsafe { arch::_mm512_mask_loadu_pd(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed double-precision (64-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_loadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_loadu_pd(k: __mmask8, mem_addr: &[f64; 8]) -> __m512d {
+    _mm512_mask_loadu_pd(arch::_mm512_setzero_pd(), k, mem_addr)
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_loadu_ps(src: __m128, k: __mmask8, mem_addr: &[f32; 4]) -> __m128 {
+    unsafe { arch::_mm_mask_loadu_ps(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_loadu_ps(k: __mmask8, mem_addr: &[f32; 4]) -> __m128 {
+    _mm_mask_loadu_ps(arch::_mm_setzero_ps(), k, mem_addr)
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_loadu_ps(src: __m256, k: __mmask8, mem_addr: &[f32; 8]) -> __m256 {
+    unsafe { arch::_mm256_mask_loadu_ps(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_loadu_ps(k: __mmask8, mem_addr: &[f32; 8]) -> __m256 {
+    _mm256_mask_loadu_ps(arch::_mm256_setzero_ps(), k, mem_addr)
+}
+
+/// Loads 512-bits (composed of 16 packed single-precision (32-bit)
+/// floating-point elements) from memory into result.
+/// `mem_addr` does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_loadu_ps(mem_addr: &[f32; 16]) -> __m512 {
+    unsafe { arch::_mm512_loadu_ps(mem_addr.as_ptr()) }
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using writemask k
+/// (elements are copied from src when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_loadu_ps(src: __m512, k: __mmask16, mem_addr: &[f32; 16]) -> __m512 {
+    unsafe { arch::_mm512_mask_loadu_ps(src, k, mem_addr.as_ptr()) }
+}
+
+/// Load packed single-precision (32-bit) floating-point elements from memory into dst using zeromask k
+/// (elements are zeroed out when the corresponding mask bit is not set).
+/// mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_loadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_loadu_ps(k: __mmask16, mem_addr: &[f32; 16]) -> __m512 {
+    _mm512_mask_loadu_ps(arch::_mm512_setzero_ps(), k, mem_addr)
+}
+
+/// Load 512-bits of integer data from memory into dst. mem_addr does not need to be aligned on any particular boundary.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_loadu_si512)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_loadu_si512<T: Is512BitsUnaligned>(mem_addr: &T) -> __m512i {
+    unsafe { arch::_mm512_loadu_si512(ptr::from_ref(mem_addr).cast()) }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "x86")]
@@ -731,6 +1103,546 @@ mod tests {
                 8., 7., 6., 0., 5., 0., 0., 0., 4., 3., 0., 0., 2., 0., 1., 0.,
             );
             assert_eq_m512(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[4, 3, 2, 5];
+            let r = super::_mm_loadu_epi32(black_box(a));
+            let e = arch::_mm_setr_epi32(4, 3, 2, 5);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4];
+            let m = 0b1010;
+            let r = super::_mm_mask_loadu_epi32(src, m, black_box(a));
+            let e = arch::_mm_setr_epi32(42, 2, 42, 4);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4];
+            let m = 0b1010;
+            let r = super::_mm_maskz_loadu_epi32(m, black_box(a));
+            let e = arch::_mm_setr_epi32(0, 2, 0, 4);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm256_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[4, 3, 2, 5, 8, 9, 64, 50];
+            let r = super::_mm256_loadu_epi32(black_box(a));
+            let e = arch::_mm256_setr_epi32(4, 3, 2, 5, 8, 9, 64, 50);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11001010;
+            let r = super::_mm256_mask_loadu_epi32(src, m, black_box(a));
+            let e = arch::_mm256_setr_epi32(42, 2, 42, 4, 42, 42, 7, 8);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11001010;
+            let r = super::_mm256_maskz_loadu_epi32(m, black_box(a));
+            let e = arch::_mm256_setr_epi32(0, 2, 0, 4, 0, 0, 7, 8);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm512_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[4, 3, 2, 5, 8, 9, 64, 50, -4, -3, -2, -5, -8, -9, -64, -50];
+            let r = super::_mm512_loadu_epi32(black_box(a));
+            let e =
+                arch::_mm512_setr_epi32(4, 3, 2, 5, 8, 9, 64, 50, -4, -3, -2, -5, -8, -9, -64, -50);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_mask_loadu_epi32(src, m, black_box(a));
+            let e =
+                arch::_mm512_setr_epi32(42, 2, 42, 4, 42, 42, 7, 8, 42, 42, 42, 12, 42, 14, 15, 16);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_loadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_maskz_loadu_epi32(m, black_box(a));
+            let e = arch::_mm512_setr_epi32(0, 2, 0, 4, 0, 0, 7, 8, 0, 0, 0, 12, 0, 14, 15, 16);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1i64, 2];
+            let r = super::_mm_loadu_epi64(a);
+            let e = arch::_mm_set_epi64x(2, 1);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_epi64x(42);
+            let a = &[1_i64, 2];
+            let m = 0b10;
+            let r = super::_mm_mask_loadu_epi64(src, m, black_box(a));
+            let e = arch::_mm_set_epi64x(2, 42);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i64, 2];
+            let m = 0b10;
+            let r = super::_mm_maskz_loadu_epi64(m, black_box(a));
+            let e = arch::_mm_set_epi64x(2, 0);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm256_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1i64, 2, 3, 4];
+            let r = super::_mm256_loadu_epi64(a);
+            let e = arch::_mm256_set_epi64x(4, 3, 2, 1);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_epi64x(42);
+            let a = &[1_i64, 2, 3, 4];
+            let m = 0b1010;
+            let r = super::_mm256_mask_loadu_epi64(src, m, black_box(a));
+            let e = arch::_mm256_setr_epi64x(42, 2, 42, 4);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i64, 2, 3, 4];
+            let m = 0b1010;
+            let r = super::_mm256_maskz_loadu_epi64(m, black_box(a));
+            let e = arch::_mm256_setr_epi64x(0, 2, 0, 4);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm512_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1_i64, 2, 3, 4, 5, 6, 7, 8];
+            let r = super::_mm512_loadu_epi64(a);
+            let e = arch::_mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_epi64(42);
+            let a = &[1_i64, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11001010;
+            let r = super::_mm512_mask_loadu_epi64(src, m, black_box(a));
+            let e = arch::_mm512_setr_epi64(42, 2, 42, 4, 42, 42, 7, 8);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_loadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1_i64, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11001010;
+            let r = super::_mm512_maskz_loadu_epi64(m, black_box(a));
+            let e = arch::_mm512_setr_epi64(0, 2, 0, 4, 0, 0, 7, 8);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_pd(42.0);
+            let a = &[1.0_f64, 2.0];
+            let m = 0b10;
+            let r = super::_mm_mask_loadu_pd(src, m, black_box(a));
+            let e = arch::_mm_setr_pd(42.0, 2.0);
+            assert_eq_m128d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0_f64, 2.0];
+            let m = 0b10;
+            let r = super::_mm_maskz_loadu_pd(m, black_box(a));
+            let e = arch::_mm_setr_pd(0.0, 2.0);
+            assert_eq_m128d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_pd(42.0);
+            let a = &[1.0_f64, 2.0, 3.0, 4.0];
+            let m = 0b1010;
+            let r = super::_mm256_mask_loadu_pd(src, m, black_box(a));
+            let e = arch::_mm256_setr_pd(42.0, 2.0, 42.0, 4.0);
+            assert_eq_m256d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0_f64, 2.0, 3.0, 4.0];
+            let m = 0b1010;
+            let r = super::_mm256_maskz_loadu_pd(m, black_box(a));
+            let e = arch::_mm256_setr_pd(0.0, 2.0, 0.0, 4.0);
+            assert_eq_m256d(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm512_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[4., 3., 2., 5., 8., 9., 64., 50.];
+            let r = super::_mm512_loadu_pd(black_box(a));
+            let e = arch::_mm512_setr_pd(4., 3., 2., 5., 8., 9., 64., 50.);
+            assert_eq_m512d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_pd(42.0);
+            let a = &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+            let m = 0b11001010;
+            let r = super::_mm512_mask_loadu_pd(src, m, black_box(a));
+            let e = arch::_mm512_setr_pd(42.0, 2.0, 42.0, 4.0, 42.0, 42.0, 7.0, 8.0);
+            assert_eq_m512d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_loadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+            let m = 0b11001010;
+            let r = super::_mm512_maskz_loadu_pd(m, black_box(a));
+            let e = arch::_mm512_setr_pd(0.0, 2.0, 0.0, 4.0, 0.0, 0.0, 7.0, 8.0);
+            assert_eq_m512d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_ps(42.0);
+            let a = &[1.0_f32, 2.0, 3.0, 4.0];
+            let m = 0b1010;
+            let r = super::_mm_mask_loadu_ps(src, m, black_box(a));
+            let e = arch::_mm_setr_ps(42.0, 2.0, 42.0, 4.0);
+            assert_eq_m128(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0_f32, 2.0, 3.0, 4.0];
+            let m = 0b1010;
+            let r = super::_mm_maskz_loadu_ps(m, black_box(a));
+            let e = arch::_mm_setr_ps(0.0, 2.0, 0.0, 4.0);
+            assert_eq_m128(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_ps(42.0);
+            let a = &[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+            let m = 0b11001010;
+            let r = super::_mm256_mask_loadu_ps(src, m, black_box(a));
+            let e = arch::_mm256_setr_ps(42.0, 2.0, 42.0, 4.0, 42.0, 42.0, 7.0, 8.0);
+            assert_eq_m256(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+            let m = 0b11001010;
+            let r = super::_mm256_maskz_loadu_ps(m, black_box(a));
+            let e = arch::_mm256_setr_ps(0.0, 2.0, 0.0, 4.0, 0.0, 0.0, 7.0, 8.0);
+            assert_eq_m256(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm512_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[
+                4., 3., 2., 5., 8., 9., 64., 50., -4., -3., -2., -5., -8., -9., -64., -50.,
+            ];
+            let r = super::_mm512_loadu_ps(black_box(a));
+            let e = arch::_mm512_setr_ps(
+                4., 3., 2., 5., 8., 9., 64., 50., -4., -3., -2., -5., -8., -9., -64., -50.,
+            );
+            assert_eq_m512(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_ps(42.0);
+            let a = &[
+                1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
+                15.0, 16.0,
+            ];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_mask_loadu_ps(src, m, black_box(a));
+            let e = arch::_mm512_setr_ps(
+                42.0, 2.0, 42.0, 4.0, 42.0, 42.0, 7.0, 8.0, 42.0, 42.0, 42.0, 12.0, 42.0, 14.0,
+                15.0, 16.0,
+            );
+            assert_eq_m512(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_loadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[
+                1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
+                15.0, 16.0,
+            ];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_maskz_loadu_ps(m, black_box(a));
+            let e = arch::_mm512_setr_ps(
+                0.0, 2.0, 0.0, 4.0, 0.0, 0.0, 7.0, 8.0, 0.0, 0.0, 0.0, 12.0, 0.0, 14.0, 15.0, 16.0,
+            );
+            assert_eq_m512(r, e);
+        }
+    }
+
+    #[test]
+    fn test_mm512_loadu_si512() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[4, 3, 2, 5, 8, 9, 64, 50, -4, -3, -2, -5, -8, -9, -64, -50];
+            let r = super::_mm512_loadu_si512(black_box(a));
+            let e =
+                arch::_mm512_setr_epi32(4, 3, 2, 5, 8, 9, 64, 50, -4, -3, -2, -5, -8, -9, -64, -50);
+            assert_eq_m512i(r, e);
         }
     }
 }

--- a/src/x86/avx512f.rs
+++ b/src/x86/avx512f.rs
@@ -1,13 +1,19 @@
 #[cfg(target_arch = "x86")]
-use core::arch::x86::{self as arch, __m128i, __mmask8};
+use core::arch::x86::{
+    self as arch, __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i,
+    __mmask8, __mmask16,
+};
 #[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::{self as arch, __m128i, __mmask8};
+use core::arch::x86_64::{
+    self as arch, __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i,
+    __mmask8, __mmask16,
+};
 use core::ptr;
 
 #[cfg(target_arch = "x86")]
-use crate::x86::Is128BitsUnaligned;
+use crate::x86::{Is128BitsUnaligned, Is256BitsUnaligned, Is512BitsUnaligned};
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::Is128BitsUnaligned;
+use crate::x86_64::{Is128BitsUnaligned, Is256BitsUnaligned, Is512BitsUnaligned};
 
 /// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
 ///
@@ -31,23 +37,296 @@ pub fn _mm_maskz_expandloadu_epi32<T: Is128BitsUnaligned>(k: __mmask8, mem_addr:
     _mm_mask_expandloadu_epi32(arch::_mm_setzero_si128(), k, mem_addr)
 }
 
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_expandloadu_epi32<T: Is256BitsUnaligned>(
+    src: __m256i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m256i {
+    unsafe { arch::_mm256_mask_expandloadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_expandloadu_epi32<T: Is256BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m256i {
+    _mm256_mask_expandloadu_epi32(arch::_mm256_setzero_si256(), k, mem_addr)
+}
+
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_expandloadu_epi32<T: Is512BitsUnaligned>(
+    src: __m512i,
+    k: __mmask16,
+    mem_addr: &T,
+) -> __m512i {
+    unsafe { arch::_mm512_mask_expandloadu_epi32(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_expandloadu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_expandloadu_epi32<T: Is512BitsUnaligned>(
+    k: __mmask16,
+    mem_addr: &T,
+) -> __m512i {
+    _mm512_mask_expandloadu_epi32(arch::_mm512_setzero_si512(), k, mem_addr)
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_expandloadu_epi64<T: Is128BitsUnaligned>(
+    src: __m128i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m128i {
+    unsafe { arch::_mm_mask_expandloadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_expandloadu_epi64<T: Is128BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m128i {
+    _mm_mask_expandloadu_epi64(arch::_mm_setzero_si128(), k, mem_addr)
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_expandloadu_epi64<T: Is256BitsUnaligned>(
+    src: __m256i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m256i {
+    unsafe { arch::_mm256_mask_expandloadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_expandloadu_epi64<T: Is256BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m256i {
+    _mm256_mask_expandloadu_epi64(arch::_mm256_setzero_si256(), k, mem_addr)
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_expandloadu_epi64<T: Is512BitsUnaligned>(
+    src: __m512i,
+    k: __mmask8,
+    mem_addr: &T,
+) -> __m512i {
+    unsafe { arch::_mm512_mask_expandloadu_epi64(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active 64-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_expandloadu_epi64)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_expandloadu_epi64<T: Is512BitsUnaligned>(k: __mmask8, mem_addr: &T) -> __m512i {
+    _mm512_mask_expandloadu_epi64(arch::_mm512_setzero_si512(), k, mem_addr)
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_expandloadu_pd(src: __m128d, k: __mmask8, mem_addr: &[f64; 2]) -> __m128d {
+    unsafe { arch::_mm_mask_expandloadu_pd(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_expandloadu_pd(k: __mmask8, mem_addr: &[f64; 2]) -> __m128d {
+    _mm_mask_expandloadu_pd(arch::_mm_setzero_pd(), k, mem_addr)
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_expandloadu_pd(src: __m256d, k: __mmask8, mem_addr: &[f64; 4]) -> __m256d {
+    unsafe { arch::_mm256_mask_expandloadu_pd(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_expandloadu_pd(k: __mmask8, mem_addr: &[f64; 4]) -> __m256d {
+    _mm256_mask_expandloadu_pd(arch::_mm256_setzero_pd(), k, mem_addr)
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_expandloadu_pd(src: __m512d, k: __mmask8, mem_addr: &[f64; 8]) -> __m512d {
+    unsafe { arch::_mm512_mask_expandloadu_pd(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active double-precision (64-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_expandloadu_pd)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_expandloadu_pd(k: __mmask8, mem_addr: &[f64; 8]) -> __m512d {
+    _mm512_mask_expandloadu_pd(arch::_mm512_setzero_pd(), k, mem_addr)
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_expandloadu_ps(src: __m128, k: __mmask8, mem_addr: &[f32; 4]) -> __m128 {
+    unsafe { arch::_mm_mask_expandloadu_ps(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_maskz_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_maskz_expandloadu_ps(k: __mmask8, mem_addr: &[f32; 4]) -> __m128 {
+    _mm_mask_expandloadu_ps(arch::_mm_setzero_ps(), k, mem_addr)
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_expandloadu_ps(src: __m256, k: __mmask8, mem_addr: &[f32; 8]) -> __m256 {
+    unsafe { arch::_mm256_mask_expandloadu_ps(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_maskz_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_maskz_expandloadu_ps(k: __mmask8, mem_addr: &[f32; 8]) -> __m256 {
+    _mm256_mask_expandloadu_ps(arch::_mm256_setzero_ps(), k, mem_addr)
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_expandloadu_ps(src: __m512, k: __mmask16, mem_addr: &[f32; 16]) -> __m512 {
+    unsafe { arch::_mm512_mask_expandloadu_ps(src, k, ptr::from_ref(mem_addr).cast()) }
+}
+
+/// Load contiguous active single-precision (32-bit) floating-point elements from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_maskz_expandloadu_ps)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_maskz_expandloadu_ps(k: __mmask16, mem_addr: &[f32; 16]) -> __m512 {
+    _mm512_mask_expandloadu_ps(arch::_mm512_setzero_ps(), k, mem_addr)
+}
+
 #[cfg(feature = "avx512f")]
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "x86")]
-    use core::arch::x86::{self as arch, __m128i};
+    use core::arch::x86::{
+        self as arch, __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i,
+    };
     #[cfg(target_arch = "x86_64")]
-    use core::arch::x86_64::{self as arch, __m128i};
+    use core::arch::x86_64::{
+        self as arch, __m128, __m128d, __m128i, __m256, __m256d, __m256i, __m512, __m512d, __m512i,
+    };
 
     use core::hint::black_box;
 
-    // Fail-safe for tests being run on a CPU that doesn't support the instructions
+    // Fail-safe for tests being run on a CPU that doesn't support the instruction set
     static CPU_HAS_AVX512VL: std::sync::LazyLock<bool> =
         std::sync::LazyLock::new(|| is_x86_feature_detected!("avx512vl"));
+
+    fn assert_eq_m128(a: __m128, b: __m128) {
+        let a: [u8; 16] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 16] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m128d(a: __m128d, b: __m128d) {
+        let a: [u8; 16] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 16] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
 
     fn assert_eq_m128i(a: __m128i, b: __m128i) {
         let a: [u8; 16] = unsafe { core::mem::transmute(a) };
         let b: [u8; 16] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m256(a: __m256, b: __m256) {
+        let a: [u8; 32] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 32] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m256d(a: __m256d, b: __m256d) {
+        let a: [u8; 32] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 32] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m256i(a: __m256i, b: __m256i) {
+        let a: [u8; 32] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 32] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m512(a: __m512, b: __m512) {
+        let a: [u8; 64] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 64] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m512d(a: __m512d, b: __m512d) {
+        let a: [u8; 64] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 64] = unsafe { core::mem::transmute(b) };
+        assert_eq!(a, b)
+    }
+
+    fn assert_eq_m512i(a: __m512i, b: __m512i) {
+        let a: [u8; 64] = unsafe { core::mem::transmute(a) };
+        let b: [u8; 64] = unsafe { core::mem::transmute(b) };
         assert_eq!(a, b)
     }
 
@@ -81,6 +360,377 @@ mod tests {
             let r = super::_mm_maskz_expandloadu_epi32(m, black_box(a));
             let e = arch::_mm_set_epi32(1, 0, 0, 0);
             assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11101000;
+            let r = super::_mm256_mask_expandloadu_epi32(src, m, black_box(a));
+            let e = arch::_mm256_set_epi32(4, 3, 2, 42, 1, 42, 42, 42);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11101000;
+            let r = super::_mm256_maskz_expandloadu_epi32(m, black_box(a));
+            let e = arch::_mm256_set_epi32(4, 3, 2, 0, 1, 0, 0, 0);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_epi32(42);
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_mask_expandloadu_epi32(src, m, black_box(a));
+            let e = arch::_mm512_set_epi32(8, 7, 6, 42, 5, 42, 42, 42, 4, 3, 42, 42, 2, 42, 1, 42);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_expandloadu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1_i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_maskz_expandloadu_epi32(m, black_box(a));
+            let e = arch::_mm512_set_epi32(8, 7, 6, 0, 5, 0, 0, 0, 4, 3, 0, 0, 2, 0, 1, 0);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_epi64x(42);
+            let a = &[1_i64, 2];
+            let m = 0b11101000;
+            let r = super::_mm_mask_expandloadu_epi64(src, m, black_box(a));
+            let e = arch::_mm_set_epi64x(42, 42);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i64, 2];
+            let m = 0b11101000;
+            let r = super::_mm_maskz_expandloadu_epi64(m, black_box(a));
+            let e = arch::_mm_set_epi64x(0, 0);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_epi64x(42);
+            let a = &[1_i64, 2, 3, 4];
+            let m = 0b11101000;
+            let r = super::_mm256_mask_expandloadu_epi64(src, m, black_box(a));
+            let e = arch::_mm256_set_epi64x(1, 42, 42, 42);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1_i64, 2, 3, 4];
+            let m = 0b11101000;
+            let r = super::_mm256_maskz_expandloadu_epi64(m, black_box(a));
+            let e = arch::_mm256_set_epi64x(1, 0, 0, 0);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_epi64(42);
+            let a = &[1_i64, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11101000;
+            let r = super::_mm512_mask_expandloadu_epi64(src, m, black_box(a));
+            let e = arch::_mm512_set_epi64(4, 3, 2, 42, 1, 42, 42, 42);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_expandloadu_epi64() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1_i64, 2, 3, 4, 5, 6, 7, 8];
+            let m = 0b11101000;
+            let r = super::_mm512_maskz_expandloadu_epi64(m, black_box(a));
+            let e = arch::_mm512_set_epi64(4, 3, 2, 0, 1, 0, 0, 0);
+            assert_eq_m512i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_pd(42.);
+            let a = &[1.0f64, 2.];
+            let m = 0b11101000;
+            let r = super::_mm_mask_expandloadu_pd(src, m, black_box(a));
+            let e = arch::_mm_set_pd(42., 42.);
+            assert_eq_m128d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0f64, 2.];
+            let m = 0b11101000;
+            let r = super::_mm_maskz_expandloadu_pd(m, black_box(a));
+            let e = arch::_mm_set_pd(0., 0.);
+            assert_eq_m128d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_pd(42.);
+            let a = &[1.0f64, 2., 3., 4.];
+            let m = 0b11101000;
+            let r = super::_mm256_mask_expandloadu_pd(src, m, black_box(a));
+            let e = arch::_mm256_set_pd(1., 42., 42., 42.);
+            assert_eq_m256d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0f64, 2., 3., 4.];
+            let m = 0b11101000;
+            let r = super::_mm256_maskz_expandloadu_pd(m, black_box(a));
+            let e = arch::_mm256_set_pd(1., 0., 0., 0.);
+            assert_eq_m256d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_pd(42.);
+            let a = &[1.0f64, 2., 3., 4., 5., 6., 7., 8.];
+            let m = 0b11101000;
+            let r = super::_mm512_mask_expandloadu_pd(src, m, black_box(a));
+            let e = arch::_mm512_set_pd(4., 3., 2., 42., 1., 42., 42., 42.);
+            assert_eq_m512d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_expandloadu_pd() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[1.0f64, 2., 3., 4., 5., 6., 7., 8.];
+            let m = 0b11101000;
+            let r = super::_mm512_maskz_expandloadu_pd(m, black_box(a));
+            let e = arch::_mm512_set_pd(4., 3., 2., 0., 1., 0., 0., 0.);
+            assert_eq_m512d(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm_set1_ps(42.);
+            let a = &[1.0f32, 2., 3., 4.];
+            let m = 0b11101000;
+            let r = super::_mm_mask_expandloadu_ps(src, m, black_box(a));
+            let e = arch::_mm_set_ps(1., 42., 42., 42.);
+            assert_eq_m128(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_maskz_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0f32, 2., 3., 4.];
+            let m = 0b11101000;
+            let r = super::_mm_maskz_expandloadu_ps(m, black_box(a));
+            let e = arch::_mm_set_ps(1., 0., 0., 0.);
+            assert_eq_m128(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let src = arch::_mm256_set1_ps(42.);
+            let a = &[1.0f32, 2., 3., 4., 5., 6., 7., 8.];
+            let m = 0b11101000;
+            let r = super::_mm256_mask_expandloadu_ps(src, m, black_box(a));
+            let e = arch::_mm256_set_ps(4., 3., 2., 42., 1., 42., 42., 42.);
+            assert_eq_m256(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_maskz_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = &[1.0f32, 2., 3., 4., 5., 6., 7., 8.];
+            let m = 0b11101000;
+            let r = super::_mm256_maskz_expandloadu_ps(m, black_box(a));
+            let e = arch::_mm256_set_ps(4., 3., 2., 0., 1., 0., 0., 0.);
+            assert_eq_m256(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let src = arch::_mm512_set1_ps(42.);
+            let a = &[
+                1.0f32, 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
+            ];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_mask_expandloadu_ps(src, m, black_box(a));
+            let e = arch::_mm512_set_ps(
+                8., 7., 6., 42., 5., 42., 42., 42., 4., 3., 42., 42., 2., 42., 1., 42.,
+            );
+            assert_eq_m512(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_maskz_expandloadu_ps() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = &[
+                1.0f32, 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
+            ];
+            let m = 0b11101000_11001010;
+            let r = super::_mm512_maskz_expandloadu_ps(m, black_box(a));
+            let e = arch::_mm512_set_ps(
+                8., 7., 6., 0., 5., 0., 0., 0., 4., 3., 0., 0., 2., 0., 1., 0.,
+            );
+            assert_eq_m512(r, e);
         }
     }
 }


### PR DESCRIPTION
Add `avx512` crate feature for AVX-512 intrinsics
Add CI step to test this feature
Add `Is512BitsUnaligned` trait to `common_traits.rs`
Add `avx512` target features and feature to Miri testing