### PR TITLE
Prepare `0.2.2-rc.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `safe_unaligned_simd` changelog
 
+## Version 0.2.2-rc.1 - 2025-08
+
+Added support for `wasm32` intrinsics under the `simd128` target feature.
+
+- [`#12`][12] - Provide intrinsics for wasm32
+
 ## Version 0.2.1 - 2025-07
 
 No functional change.  
@@ -47,6 +53,7 @@ The functions are located within an architecture's `cell` module.
 
 Initial release
 
+[12]: https://github.com/okaneco/safe_unaligned_simd/pull/12
 [15]: https://github.com/okaneco/safe_unaligned_simd/pull/15
 [8]: https://github.com/okaneco/safe_unaligned_simd/pull/8
 [6]: https://github.com/okaneco/safe_unaligned_simd/pull/6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_unaligned_simd"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -39,4 +39,4 @@ _assembly_x86 = []
 no-default-features = true
 features = [""]
 default-target = "x86_64-unknown-linux-gnu"
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "i686-unknown-linux-gnu", "wasm32-wasip1"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Platform-intrinsics that take raw pointers have been wrapped in functions that r
 Some functions have variants that are generic over `Cell` array types, which allow for mutation of shared references.
 See the [`cell`](./src/x86/cell.rs) module for an example.
 
-Some example function signatures:
+Example function signatures:
 ```rust
 #[target_feature(enable = "sse")]
 fn _mm_storeu_ps(mem_addr: &mut [f32; 4], a: __m128);
@@ -35,12 +35,23 @@ Currently, there is no plan to implement gather/scatter or masked load/store int
 ### `aarch64` / `arm64ec`
 - `neon`
 
-Some example function signatures:
+Example function signatures:
 ```rust
 #[target_feature(enable = "neon")]
 fn vld2_dup_s8(from: &[i8; 2]) -> int8x8x2_t;
 #[target_feature(enable = "neon")]
 fn vst1q_f64(into: &mut [f64; 2], val: float64x2_t);
+```
+
+### `wasm32`
+- `simd128`
+
+Example function signatures:
+```rust
+#[target_feature(enable = "simd128")]
+pub fn v128_load8_splat<T: Is1ByteUnaligned>(t: &T) -> v128;
+#[target_feature(enable = "simd128")]
+pub fn v128_store<T: Is16BytesUnaligned>(t: &mut T, v: v128);
 ```
 
 ## License

--- a/src/wasm32.rs
+++ b/src/wasm32.rs
@@ -2,7 +2,7 @@
 use core::arch::wasm32::{self as arch, v128};
 use core::ptr;
 
-use crate::common_traits::{
+pub use crate::common_traits::{
     Is8BitsUnaligned as Is1ByteUnaligned, Is16BitsUnaligned as Is2BytesUnaligned,
     Is32BitsUnaligned as Is4BytesUnaligned, Is64BitsUnaligned as Is8BytesUnaligned,
     Is128BitsUnaligned as Is16BytesUnaligned,


### PR DESCRIPTION
Bump crate version
Add `wasm32-wasip1` target to docs.rs metadata
Update changelog
Update readme
Export the traits publicly from wasm32 module, matching x86 behavior

Marking this as a release candidate to test the docs build for wasm