### PR TITLE
Implement `AVX-512F` intrinsic support, implement `cvt` intrinsics [3/3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Platform-intrinsics that take raw pointers have been wrapped in functions that r
 ## Supported target architectures
 
 ### `x86` / `x86_64`
-- `sse`, `sse2`, `avx`
+- `sse`, `sse2`, `avx`, `avx512f`, `avx512vl`, `avx512bw`, `avx512vbmi2`
 
 Some functions have variants that are generic over `Cell` array types, which allow for mutation of shared references.
 See the [`cell`](./src/x86/cell.rs) module for an example.
@@ -30,7 +30,7 @@ fn _mm_store_sd(mem_addr: &mut f64, a: __m128d);
 fn _mm256_loadu2_m128(hiaddr: &[f32; 4], loaddr: &[f32; 4]) -> __m256;
 ```
 
-Currently, there is no plan to implement gather/scatter or masked load/store intrinsics for this platform.
+Currently, there is no plan to implement gather/scatter or `avx2` masked load/store intrinsics for this platform.
 
 ### `aarch64` / `arm64ec`
 - `neon`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,13 @@
 //! ## Supported target architectures
 //!
 //! ### `x86` / `x86_64`
-//! - `sse`, `sse2`, `avx`
+//! - `sse`, `sse2`, `avx`, `avx512f`, `avx512vl`, `avx512bw`, `avx512vbmi2`
 //!
 //! Some functions have variants that are generic over `Cell` array types,
 //! which allow for mutation of shared references.
 //!
-//! Currently, there is no plan to implement gather/scatter or masked load/store
-//! intrinsics for this platform.
+//! Currently, there is no plan to implement gather/scatter or `avx2` masked
+//! load/store intrinsics for this platform.
 //!
 //! ### `aarch64`, `arm64ec`
 //! - `neon`

--- a/src/x86/avx512f.rs
+++ b/src/x86/avx512f.rs
@@ -11,9 +11,15 @@ use core::arch::x86_64::{
 use core::ptr;
 
 #[cfg(target_arch = "x86")]
-use crate::x86::{Is128BitsUnaligned, Is256BitsUnaligned, Is512BitsUnaligned};
+use crate::x86::{
+    Is16BitsUnaligned, Is32BitsUnaligned, Is64BitsUnaligned, Is128BitsUnaligned,
+    Is256BitsUnaligned, Is512BitsUnaligned,
+};
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::{Is128BitsUnaligned, Is256BitsUnaligned, Is512BitsUnaligned};
+use crate::x86_64::{
+    Is16BitsUnaligned, Is32BitsUnaligned, Is64BitsUnaligned, Is128BitsUnaligned,
+    Is256BitsUnaligned, Is512BitsUnaligned,
+};
 
 /// Load contiguous active 32-bit integers from unaligned memory at mem_addr (those with their respective bit set in mask k), and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
 ///
@@ -763,6 +769,591 @@ pub fn _mm256_mask_compressstoreu_ps(base_addr: &mut [f32; 8], k: __mmask8, a: _
 #[target_feature(enable = "avx512f")]
 pub fn _mm512_mask_compressstoreu_ps(base_addr: &mut [f32; 16], k: __mmask16, a: __m512) {
     unsafe { arch::_mm512_mask_compressstoreu_ps(base_addr.as_mut_ptr().cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtepi32_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtepi32_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtepi32_storeu_epi16<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtepi32_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtepi32_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 32-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtepi32_storeu_epi8<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtepi64_storeu_epi16<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtepi64_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 16-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtepi64_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+///Convert packed 64-bit integers in a to packed 32-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtepi64_storeu_epi32<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+///Convert packed 64-bit integers in a to packed 32-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtepi64_storeu_epi32<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+///Convert packed 64-bit integers in a to packed 32-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtepi64_storeu_epi32<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtepi64_storeu_epi8<T: Is16BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtepi64_storeu_epi8<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed 64-bit integers in a to packed 8-bit integers with truncation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtepi64_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtsepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtsepi32_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtsepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtsepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtsepi32_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtsepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtsepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtsepi32_storeu_epi16<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtsepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtsepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtsepi32_storeu_epi8<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtsepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtsepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtsepi32_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtsepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 32-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtsepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtsepi32_storeu_epi8<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtsepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtsepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtsepi64_storeu_epi16<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtsepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtsepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtsepi64_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtsepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 16-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtsepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtsepi64_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtsepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 32-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtsepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtsepi64_storeu_epi32<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtsepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 32-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtsepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtsepi64_storeu_epi32<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtsepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 32-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtsepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtsepi64_storeu_epi32<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtsepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtsepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtsepi64_storeu_epi8<T: Is16BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtsepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtsepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtsepi64_storeu_epi8<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtsepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed signed 64-bit integers in a to packed 8-bit integers with signed saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtsepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtsepi64_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtsepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed unsigned 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtusepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtusepi32_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtusepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed unsigned 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtusepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtusepi32_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtusepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtusepi32_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtusepi32_storeu_epi16<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtusepi32_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtusepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtusepi32_storeu_epi8<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtusepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtusepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtusepi32_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtusepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 32-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtusepi32_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtusepi32_storeu_epi8<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask16,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtusepi32_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtusepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtusepi64_storeu_epi16<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtusepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtusepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtusepi64_storeu_epi16<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtusepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 16-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtusepi64_storeu_epi16)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtusepi64_storeu_epi16<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtusepi64_storeu_epi16(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 32-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtusepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtusepi64_storeu_epi32<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtusepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 32-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtusepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtusepi64_storeu_epi32<T: Is128BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtusepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 32-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtusepi64_storeu_epi32)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtusepi64_storeu_epi32<T: Is256BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtusepi64_storeu_epi32(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mask_cvtusepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm_mask_cvtusepi64_storeu_epi8<T: Is16BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m128i,
+) {
+    unsafe { arch::_mm_mask_cvtusepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_mask_cvtusepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f,avx512vl")]
+pub fn _mm256_mask_cvtusepi64_storeu_epi8<T: Is32BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m256i,
+) {
+    unsafe { arch::_mm256_mask_cvtusepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
+}
+
+/// Convert packed unsigned 64-bit integers in a to packed 8-bit integers with unsigned saturation, and store the active results (those with their respective bit set in writemask k) to unaligned memory at base_addr.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_mask_cvtusepi64_storeu_epi8)
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub fn _mm512_mask_cvtusepi64_storeu_epi8<T: Is64BitsUnaligned>(
+    base_addr: &mut T,
+    k: __mmask8,
+    a: __m512i,
+) {
+    unsafe { arch::_mm512_mask_cvtusepi64_storeu_epi8(ptr::from_mut(base_addr).cast(), k, a) }
 }
 
 /// Store packed 32-bit integers from a into memory using writemask k.
@@ -2203,6 +2794,726 @@ mod tests {
                     0_f32, 0_f32, 0_f32, 0_f32, 0_f32, 0_f32
                 ]
             );
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(9);
+            let mut r = [0u16; 4];
+            super::_mm_mask_cvtepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [9u16; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(9);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm256_mask_cvtepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(9);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(9);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtepi32_storeu_epi16(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm256_set1_epi16(9);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(9);
+            let mut r = [0u8; 8];
+            super::_mm_mask_cvtepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [9, 9, 9, 9, 0, 0, 0, 0];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(9);
+            let mut r = [0u8; 8];
+            super::_mm256_mask_cvtepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [9u8; 8];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(9);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtepi32_storeu_epi8(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm_set1_epi8(9);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(9);
+            let mut r = [0u16; 2];
+            super::_mm_mask_cvtepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [9; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(9);
+            let mut r = [0u16; 4];
+            super::_mm256_mask_cvtepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [9; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(9);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(9);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(9);
+            let mut r = [0u32; 2];
+            super::_mm_mask_cvtepi64_storeu_epi32(&mut r, 0b11111111, a);
+            let e = [9; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(9);
+            let mut r = arch::_mm_set1_epi32(0);
+            super::_mm256_mask_cvtepi64_storeu_epi32(&mut r, 0b11111111, a);
+            let e = arch::_mm_set_epi32(9, 9, 9, 9);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(9);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtepi64_storeu_epi32(&mut r, 0b11111111, a);
+            let e = arch::_mm256_set1_epi32(9);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(9);
+            let mut r = [0u8; 2];
+            super::_mm_mask_cvtepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [9; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(9);
+            let mut r = [0u8; 4];
+            super::_mm256_mask_cvtepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [9; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(9);
+            let mut r = [0u8; 8];
+            super::_mm512_mask_cvtepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [9; 8];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtsepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(i32::MAX);
+            let mut r = [0i16; 4];
+            super::_mm_mask_cvtsepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [i16::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtsepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(i32::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm256_mask_cvtsepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(i16::MAX);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtsepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(i32::MAX);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtsepi32_storeu_epi16(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm256_set1_epi16(i16::MAX);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtsepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(i32::MAX);
+            let mut r = [0i8; 4];
+            super::_mm_mask_cvtsepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [i8::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtsepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(i32::MAX);
+            let mut r = [0i8; 8];
+            super::_mm256_mask_cvtsepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [i8::MAX; 8];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtsepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(i32::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtsepi32_storeu_epi8(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm_set1_epi8(i8::MAX);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtsepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0i16; 2];
+            super::_mm_mask_cvtsepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [i16::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtsepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = [0i16; 4];
+            super::_mm256_mask_cvtsepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [i16::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtsepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtsepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(i16::MAX);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtsepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0i32; 2];
+            super::_mm_mask_cvtsepi64_storeu_epi32(&mut r, 0b00000011, a);
+            let e = [i32::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtsepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = arch::_mm_set1_epi32(0);
+            super::_mm256_mask_cvtsepi64_storeu_epi32(&mut r, 0b00001111, a);
+            let e = arch::_mm_set1_epi32(i32::MAX);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtsepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtsepi64_storeu_epi32(&mut r, 0b11111111, a);
+            let e = arch::_mm256_set1_epi32(i32::MAX);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtsepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0i8; 2];
+            super::_mm_mask_cvtsepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [i8::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtsepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = [0i8; 4];
+            super::_mm256_mask_cvtsepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [i8::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtsepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = [0i8; 8];
+            super::_mm512_mask_cvtsepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [i8::MAX; 8];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtusepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(i32::MAX);
+            let mut r = [0u16; 4];
+            super::_mm_mask_cvtusepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [u16::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtusepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(i32::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm256_mask_cvtusepi32_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(u16::MAX as i16);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtusepi32_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(i32::MAX);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtusepi32_storeu_epi16(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm256_set1_epi16(u16::MAX as i16);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtusepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi32(i32::MAX);
+            let mut r = [0u8; 4];
+            super::_mm_mask_cvtusepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [u8::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtusepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi32(i32::MAX);
+            let mut r = [0u8; 8];
+            super::_mm256_mask_cvtusepi32_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [u8::MAX; 8];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtusepi32_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi32(i32::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtusepi32_storeu_epi8(&mut r, 0b11111111_11111111, a);
+            let e = arch::_mm_set1_epi8(u8::MAX as i8);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtusepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0u16; 2];
+            super::_mm_mask_cvtusepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [u16::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtusepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = [0u16; 4];
+            super::_mm256_mask_cvtusepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = [u16::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtusepi64_storeu_epi16() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = arch::_mm_undefined_si128();
+            super::_mm512_mask_cvtusepi64_storeu_epi16(&mut r, 0b11111111, a);
+            let e = arch::_mm_set1_epi16(u16::MAX as i16);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtusepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0u32; 2];
+            super::_mm_mask_cvtusepi64_storeu_epi32(&mut r, 0b00000011, a);
+            let e = [u32::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtusepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = arch::_mm_set1_epi32(0);
+            super::_mm256_mask_cvtusepi64_storeu_epi32(&mut r, 0b00001111, a);
+            let e = arch::_mm_set1_epi32(u32::MAX as i32);
+            assert_eq_m128i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtusepi64_storeu_epi32() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = arch::_mm256_undefined_si256();
+            super::_mm512_mask_cvtusepi64_storeu_epi32(&mut r, 0b11111111, a);
+            let e = arch::_mm256_set1_epi32(u32::MAX as i32);
+            assert_eq_m256i(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm_mask_cvtusepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm_set1_epi64x(i64::MAX);
+            let mut r = [0u8; 2];
+            super::_mm_mask_cvtusepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [u8::MAX; 2];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm256_mask_cvtusepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f,avx512vl")]
+        fn test() {
+            let a = arch::_mm256_set1_epi64x(i64::MAX);
+            let mut r = [0u8; 4];
+            super::_mm256_mask_cvtusepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [u8::MAX; 4];
+            assert_eq!(r, e);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_mm512_mask_cvtusepi64_storeu_epi8() {
+        assert!(*CPU_HAS_AVX512VL);
+        unsafe { test() }
+
+        #[target_feature(enable = "avx512f")]
+        fn test() {
+            let a = arch::_mm512_set1_epi64(i64::MAX);
+            let mut r = [0u8; 8];
+            super::_mm512_mask_cvtusepi64_storeu_epi8(&mut r, 0b11111111, a);
+            let e = [u8::MAX; 8];
+            assert_eq!(r, e);
         }
     }
 


### PR DESCRIPTION
Add the remaining `avx512f` target feature intrinsics
Update README.md and `lib.rs` to mention AVX-512 support

Closes https://github.com/okaneco/safe_unaligned_simd/pull/23

---

This was the most involved addition for the tests and API design. Each intrinsic needed to be carefully checked for the memory type in order to know which marker trait to use.

For instance, `_mm_mask_cvtepi32_storeu_epi8` takes an `m64`/`Is64BitsUnaligned` type but only stores 4 bytes.

The diff is much nicer with the `--patience` algorithm which shows `1318 insertions(+), 7 deletions(-)`.