### PR TITLE
Run 3 more tests under Miri, add docs for how to use intrinsics safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ This crate is compatible with runtime feature detection.
 
 Unlike some other safe architecture intrinsic wrappers, this crate does not lock the user into `#[cfg()]`-gating SIMD code behind compile-time CPU target feature declaration.
 
+> [!NOTE]  
+> To safely use platform intrinsics, users are responsible for ensuring that the CPU supports the intended target feature.
+>
+> Feature detection can be done at compile-time by using `#[cfg]` attributes on functions or at runtime using an `is_[arch]_feature_detected!` macro from `std::arch`.
+>
+> `unsafe` is needed to call into functions annotated with `#[target_feature]`, but [it's safe to call other functions with the same target features][rustc-1.86].
+>
+> See [the `std::arch` module documentation][stdarch] for a full explanation and [the `rustc` 1.87 release notes][rustc-1.87] for a simple example of runtime feature detection with fallback.
+
+[rustc-1.86]: https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/#allow-safe-functions-to-be-marked-with-the-target-feature-attribute
+[rustc-1.87]: https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/#safe-architecture-intrinsics
+[stdarch]: https://doc.rust-lang.org/stable/std/arch/index.html#overview
+
 ## Supported target architectures
 
 ### `x86` / `x86_64`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,20 @@
 //! Platform-intrinsics that take raw pointers have been wrapped in functions
 //! that receive Rust reference types as arguments.
 //!
+//! ## Safely using platform intrinsics
+//!
+//! Users are responsible for ensuring that the CPU supports the intended target feature.
+//!
+//! Feature detection can be done at compile-time by using `#[cfg]` attributes on functions or at runtime using an `is_[arch]_feature_detected!` macro from `std::arch`.
+//!
+//! `unsafe` is needed to call into functions annotated with `#[target_feature]`, but [it's safe to call other functions with the same target features][rustc-1.86].
+//!
+//! See [the `std::arch` module documentation][stdarch] for a full explanation and [the `rustc` 1.87 release notes][rustc-1.87] for a simple example of runtime feature detection with fallback.
+//!
+//! [rustc-1.86]: https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/#allow-safe-functions-to-be-marked-with-the-target-feature-attribute
+//! [rustc-1.87]: https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/#safe-architecture-intrinsics
+//! [stdarch]: https://doc.rust-lang.org/stable/std/arch/index.html#overview
+//!
 //! ## Supported target architectures
 //!
 //! ### `x86` / `x86_64`

--- a/src/x86/avx512bw.rs
+++ b/src/x86/avx512bw.rs
@@ -835,7 +835,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_mm_mask_cvtepi16_storeu_epi8() {
         assert!(*CPU_HAS_AVX512BW);
         unsafe { test() }
@@ -851,7 +850,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_mm256_mask_cvtepi16_storeu_epi8() {
         assert!(*CPU_HAS_AVX512BW);
         unsafe { test() }
@@ -867,7 +865,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_mm512_mask_cvtepi16_storeu_epi8() {
         assert!(*CPU_HAS_AVX512BW);
         unsafe { test() }


### PR DESCRIPTION
Allow 3 AVX-512BW tests to run under Miri after their underlying implementation was switched to using Rust intrinsics
Expand readme with links on how to safely use intrinsics

Closes #38 