### PR TITLE
Add #[inline] to all aarch64 and wasm32 functions

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -69,6 +69,7 @@ macro_rules! vld_n_replicate_k {
         $([$size:ident])?
     ) => {
         $(#[$meta])*
+        #[inline]
         #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         #[target_feature(enable = "neon")]
         pub fn $intrinsic(from: &$realty) -> $ret {
@@ -88,6 +89,7 @@ macro_rules! vld_n_replicate_k {
         $([$size:ident])?
     ) => {
         $(#[$meta])*
+        #[inline]
         #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
         #[target_feature(enable = "neon")]
         pub fn $intrinsic(into: &mut $realty, val: $ret) {

--- a/src/wasm32.rs
+++ b/src/wasm32.rs
@@ -11,6 +11,7 @@ pub use crate::common_traits::{
 /// Loads eight 8-bit integers and sign extends each one to a 16-bit lane.
 ///
 /// Safe wrapper around [`arch::i16x8_load_extend_i8x8`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i16x8_load_extend_i8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i16x8_load_extend_i8x8(ptr::from_ref(t).cast()) }
@@ -19,6 +20,7 @@ pub fn i16x8_load_extend_i8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads eight 8-bit integers and zero extends each one to a 16-bit lane.
 ///
 /// Safe wrapper around [`arch::i16x8_load_extend_u8x8`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i16x8_load_extend_u8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i16x8_load_extend_u8x8(ptr::from_ref(t).cast()) }
@@ -27,6 +29,7 @@ pub fn i16x8_load_extend_u8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads four 16-bit integers and sign extends each one to a 32-bit lane.
 ///
 /// Safe wrapper around [`arch::i32x4_load_extend_i16x4`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i32x4_load_extend_i16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i32x4_load_extend_i16x4(ptr::from_ref(t).cast()) }
@@ -35,6 +38,7 @@ pub fn i32x4_load_extend_i16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads four 16-bit integers and zero extends each one to a 32-bit lane.
 ///
 /// Safe wrapper around [`arch::i32x4_load_extend_u16x4`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i32x4_load_extend_u16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i32x4_load_extend_u16x4(ptr::from_ref(t).cast()) }
@@ -43,6 +47,7 @@ pub fn i32x4_load_extend_u16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads two 32-bit integers and sign extends each one to a 64-bit lane.
 ///
 /// Safe wrapper around [`arch::i64x2_load_extend_i32x2`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i64x2_load_extend_i32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i64x2_load_extend_i32x2(ptr::from_ref(t).cast()) }
@@ -51,6 +56,7 @@ pub fn i64x2_load_extend_i32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads two 32-bit integers and zero extends each one to a 64-bit lane.
 ///
 /// Safe wrapper around [`arch::i64x2_load_extend_u32x2`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn i64x2_load_extend_u32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::i64x2_load_extend_u32x2(ptr::from_ref(t).cast()) }
@@ -59,6 +65,7 @@ pub fn i64x2_load_extend_u32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads eight 8-bit integers and zero extends each one to a 16-bit lane.
 ///
 /// Safe wrapper around [`arch::u16x8_load_extend_u8x8`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn u16x8_load_extend_u8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::u16x8_load_extend_u8x8(ptr::from_ref(t).cast()) }
@@ -67,6 +74,7 @@ pub fn u16x8_load_extend_u8x8<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads four 16-bit integers and zero extends each one to a 32-bit lane.
 ///
 /// Safe wrapper around [`arch::u32x4_load_extend_u16x4`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn u32x4_load_extend_u16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::u32x4_load_extend_u16x4(ptr::from_ref(t).cast()) }
@@ -75,6 +83,7 @@ pub fn u32x4_load_extend_u16x4<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads two 32-bit integers and zero extends each one to a 64-bit lane.
 ///
 /// Safe wrapper around [`arch::u64x2_load_extend_u32x2`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn u64x2_load_extend_u32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::u64x2_load_extend_u32x2(ptr::from_ref(t).cast()) }
@@ -83,6 +92,7 @@ pub fn u64x2_load_extend_u32x2<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads a `v128` vector from the given heap address.
 ///
 /// Safe wrapper around [`arch::v128_load`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load<T: Is16BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load(ptr::from_ref(t).cast()) }
@@ -91,6 +101,7 @@ pub fn v128_load<T: Is16BytesUnaligned>(t: &T) -> v128 {
 /// Loads a single element and splats to all lanes of a `v128` vector.
 ///
 /// Safe wrapper around [`arch::v128_load8_splat`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load8_splat<T: Is1ByteUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load8_splat(ptr::from_ref(t).cast()) }
@@ -99,6 +110,7 @@ pub fn v128_load8_splat<T: Is1ByteUnaligned>(t: &T) -> v128 {
 /// Loads a single element and splats to all lanes of a `v128` vector.
 ///
 /// Safe wrapper around [`arch::v128_load16_splat`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load16_splat<T: Is2BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load16_splat(ptr::from_ref(t).cast()) }
@@ -107,6 +119,7 @@ pub fn v128_load16_splat<T: Is2BytesUnaligned>(t: &T) -> v128 {
 /// Loads a single element and splats to all lanes of a `v128` vector.
 ///
 /// Safe wrapper around [`arch::v128_load32_splat`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load32_splat<T: Is4BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load32_splat(ptr::from_ref(t).cast()) }
@@ -115,6 +128,7 @@ pub fn v128_load32_splat<T: Is4BytesUnaligned>(t: &T) -> v128 {
 /// Loads a 32-bit element into the low bits of the vector and sets all other bits to zero.
 ///
 /// Safe wrapper around [`arch::v128_load32_zero`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load32_zero<T: Is4BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load32_zero(ptr::from_ref(t).cast()) }
@@ -123,6 +137,7 @@ pub fn v128_load32_zero<T: Is4BytesUnaligned>(t: &T) -> v128 {
 /// Loads a single element and splats to all lanes of a `v128` vector.
 ///
 /// Safe wrapper around [`arch::v128_load64_splat`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load64_splat<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load64_splat(ptr::from_ref(t).cast()) }
@@ -131,6 +146,7 @@ pub fn v128_load64_splat<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Loads a 64-bit element into the low bits of the vector and sets all other bits to zero.
 ///
 /// Safe wrapper around [`arch::v128_load64_zero`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_load64_zero<T: Is8BytesUnaligned>(t: &T) -> v128 {
     unsafe { arch::v128_load64_zero(ptr::from_ref(t).cast()) }
@@ -139,6 +155,7 @@ pub fn v128_load64_zero<T: Is8BytesUnaligned>(t: &T) -> v128 {
 /// Stores a `v128` vector to the given heap address.
 ///
 /// Safe wrapper around [`arch::v128_store`].
+#[inline]
 #[target_feature(enable = "simd128")]
 pub fn v128_store<T: Is16BytesUnaligned>(t: &mut T, v: v128) {
     unsafe { arch::v128_store(ptr::from_mut(t).cast(), v) }


### PR DESCRIPTION
## Summary

The `vld_n_replicate_k!` macro generates ~300 aarch64 functions with `#[target_feature(enable = "neon")]` but no `#[inline]`. Similarly, all 17 wasm32 functions lack `#[inline]`. The x86/x86_64 modules already have `#[inline]` on every function.

Without `#[inline]`, rustc does not include function bodies in crate metadata, preventing cross-crate inlining. Every NEON/WASM load and store becomes a function call (`bl`/`call`) instead of a single instruction (`ldr q`/`str q`).

## Impact

Benchmarked with [garb](https://github.com/imazen/garb) (pixel swizzle crate) across Linux, macOS, and Windows aarch64 runners:

| Benchmark (8 MiB) | Before | After | Speedup |
|---|---|---|---|
| 4bpp inplace swap | 788–916 µs | 236–242 µs | **3.3–3.8x** |
| 3bpp inplace swap | 966–1292 µs | 327–369 µs | **2.6–3.5x** |
| 3bpp copy swap | 771–905 µs | 217–255 µs | **3.4–4.2x** |
| fill alpha | 771–942 µs | 236–268 µs | **3.3–3.5x** |

Before the fix, garb's NEON paths were **slower than scalar** on all aarch64 platforms. After: 2–4x faster than naive scalar loops. The release assembly went from 44 `bl` calls to `safe_unaligned_simd` functions down to 0.

## Changes

- `src/aarch64.rs`: Add `#[inline]` to both `load` and `store` arms of the `vld_n_replicate_k!` macro (2 lines, affects ~300 generated fns)
- `src/wasm32.rs`: Add `#[inline]` to all 17 hand-written functions